### PR TITLE
[lsp-ui-peek] Propagate lsp--cur-workspace when jumping to xref and enable lsp-mode when necessary

### DIFF
--- a/lsp-ui-peek.el
+++ b/lsp-ui-peek.el
@@ -392,8 +392,13 @@ X."
                             (goto-char 1)
                             (forward-line line)
                             (forward-char column)
-                            (point-marker))))))
+                            (point-marker)))))
+              (current-workspace lsp--cur-workspace))
           (switch-to-buffer (marker-buffer marker))
+          (unless lsp--cur-workspace
+            (setq lsp--cur-workspace current-workspace))
+          (unless lsp-mode
+            (lsp-mode t))
           (goto-char marker)
           (run-hooks 'xref-after-jump-hook)))
     (lsp-ui-peek--toggle-file)))


### PR DESCRIPTION
With this pr, after jumping outside of project root (e.g. system function definitions), we can still have lsp-mode enabled and the buffer associated with the original lsp--cur-worksapce.