### PR TITLE
Don’t use macro ‘when-let*’, which only exists in Emacs 26.

### DIFF
--- a/lsp-ui-peek.el
+++ b/lsp-ui-peek.el
@@ -499,7 +499,7 @@ X OTHER-WINDOW."
   :init-value nil
   (if lsp-ui-peek-mode
       (setq lsp-ui-peek--deactivate-keymap-fn (set-transient-map lsp-ui-peek-mode-map t 'lsp-ui-peek--abort))
-    (when-let* ((fn lsp-ui-peek--deactivate-keymap-fn))
+    (-when-let (fn lsp-ui-peek--deactivate-keymap-fn)
       (setq lsp-ui-peek--deactivate-keymap-fn nil)
       (funcall fn))))
 


### PR DESCRIPTION
Since lsp-ui-peek loads ‘dash’ anyway, just use its variant ‘-when-let’.