### PR TITLE
[lsp-ui-sideline] Check for capability before invoking textDocument/codeAction

### DIFF
--- a/lsp-ui-sideline.el
+++ b/lsp-ui-sideline.el
@@ -355,7 +355,7 @@ to the language server."
               lsp-ui-sideline--last-width (window-text-width))
         (when lsp-ui-sideline-show-flycheck
           (lsp-ui-sideline--flycheck))
-        (when lsp-ui-sideline-show-code-actions
+        (when (and lsp-ui-sideline-show-code-actions (lsp--capability "codeActionProvider"))
           (lsp--send-request-async (lsp--make-request
                                     "textDocument/codeAction"
                                     (list :textDocument doc-id


### PR DESCRIPTION
Sideline does not currently check caps before sending `textDocument/codeAction`. This causes an error message with php-language-server every time the cursor is moved.

I also have a question regarding PHP support - would it be possible to get the `lsp-php` repo below the `emacs-lsp` organization when I publish it? I will give it a test run at work next week and push it to GitHub after that if there are no significant problems.