### PR TITLE
Fix package headers.

### DIFF
--- a/lsp-ui-doc.el
+++ b/lsp-ui-doc.el
@@ -5,8 +5,6 @@
 ;; Author: Sebastien Chapuis <sebastien@chapu.is>
 ;; URL: https://github.com/emacs-lsp/lsp-ui
 ;; Keywords: lsp, ui
-;; Version: 0.0.1
-;; Package-Requires: ((emacs "26") (lsp-mode "3.4") (markdown-mode "1.0"))
 
 ;;; License
 ;;

--- a/lsp-ui-flycheck.el
+++ b/lsp-ui-flycheck.el
@@ -1,10 +1,8 @@
 ;;; lsp-ui-flycheck.el --- Flycheck support for lsp-mode -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2017  fmdkdd
-;; Package-Requires: ((emacs "25.1") (flycheck "30") (lsp-mode "3.1"))
 ;; URL: https://github.com/emacs-lsp/lsp-ui
 ;; Keywords: lsp, ui
-;; Version: 0.0.1
 
 ;; This program is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by

--- a/lsp-ui-imenu.el
+++ b/lsp-ui-imenu.el
@@ -5,8 +5,6 @@
 ;; Author: Sebastien Chapuis <sebastien@chapu.is>
 ;; URL: https://github.com/emacs-lsp/lsp-ui
 ;; Keywords: lsp, ui
-;; Version: 0.0.1
-;; Package-Requires: ((emacs "26") (lsp-mode "3.4"))
 
 ;;; License
 ;;

--- a/lsp-ui-peek.el
+++ b/lsp-ui-peek.el
@@ -6,7 +6,6 @@
 ;; URL: https://github.com/emacs-lsp/lsp-ui
 ;; Keywords: lsp, ui
 ;; Version: 0.0.1
-;; Package-Requires: ((emacs "25.1") (lsp-mode "3.4") (dash "0.13"))
 
 ;;; License
 ;;

--- a/lsp-ui-sideline.el
+++ b/lsp-ui-sideline.el
@@ -5,8 +5,6 @@
 ;; Author: Sebastien Chapuis <sebastien@chapu.is>
 ;; URL: https://github.com/emacs-lsp/lsp-ui
 ;; Keywords: lsp, ui
-;; Version: 0.0.1
-;; Package-Requires: ((emacs "25.1") (flycheck "0.23") (lsp-mode "3.4"))
 
 ;;; License
 ;;

--- a/lsp-ui.el
+++ b/lsp-ui.el
@@ -5,7 +5,7 @@
 ;; Author:  Tobias Pisani <topisani@hamsterpoison.com>
 ;; Keywords: lsp
 ;; URL: https://github.com/emacs-lsp/lsp-ui
-;; Package-Requires: ((emacs "25.1") (flycheck "30") (lsp-mode "3.4") (markdown-mode "2.0"))
+;; Package-Requires: ((emacs "25.1") (dash "2.13") (flycheck "31") (lsp-mode "3.4") (markdown-mode "2.3"))
 ;; Version: 0.0.1
 
 ;; Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
- Move them all to lsp-ui.el.  Right now, the other files have a cyclic
  dependency on lsp-ui.el, so they can’t be treated as separate packages.

- Add dash.el dependency.

- Update version numbers.