### PR TITLE
Fix issues with documentation strings.

### DIFF
--- a/lsp-ui-doc.el
+++ b/lsp-ui-doc.el
@@ -66,8 +66,9 @@
   :group 'lsp-ui-doc)
 
 (defcustom lsp-ui-doc-background "#272A36"
-  "Background color of the frame.  To more customize the frame, see the varia..
-ble `lsp-ui-doc-frame-parameters'"
+  "Background color of the frame.
+To more customize the frame, see the variable
+`lsp-ui-doc-frame-parameters'."
   :type 'color
   :group 'lsp-ui-doc)
 
@@ -166,7 +167,7 @@ Because some variables are buffer local.")
   `(plist-get lsp-ui-doc--parent-vars ,var))
 
 (defmacro lsp-ui-doc--set-frame (frame)
-  "Set the frame parameter 'lsp-ui-doc-frame to FRAME."
+  "Set the frame parameter ‘lsp-ui-doc-frame’ to FRAME."
   `(set-frame-parameter nil 'lsp-ui-doc-frame ,frame))
 
 (defmacro lsp-ui-doc--get-frame ()
@@ -181,20 +182,18 @@ Because some variables are buffer local.")
           "*"))
 
 (defun lsp-ui-doc--set-eldoc (marked-string)
-  "MARKED-STRING."
   (when marked-string
     (let ((string (lsp-ui-doc--extract-marked-string marked-string)))
       (setq lsp-ui-doc--string-eldoc string))))
 
 (defun lsp-ui-doc--eldoc (&rest _)
-  "."
   (when (and (lsp--capability "documentHighlightProvider")
              lsp-highlight-symbol-at-point)
     (lsp-symbol-highlight))
   lsp-ui-doc--string-eldoc)
 
 (defun lsp-ui-doc--setup-markdown (mode)
-  "Setup the markdown-mode in the frame.
+  "Setup the ‘markdown-mode’ in the frame.
 MODE is the mode used in the parent frame."
   (make-local-variable 'markdown-code-lang-modes)
   (dolist (mark (alist-get mode lsp-ui-doc-custom-markup-modes))
@@ -230,7 +229,6 @@ MODE is the mode used in the parent frame."
          (buffer-string))))))
 
 (defun lsp-ui-doc--filter-marked-string (list-marked-string)
-  "LIST-MARKED-STRING."
   (let ((groups (--separate (and (hash-table-p it)
                                  (lsp-ui-sideline--get-renderer (gethash "language" it)))
                             list-marked-string)))
@@ -314,7 +312,6 @@ BUFFER is the buffer where the request has been made."
                   (window-line-height line)))))
 
 (defun lsp-ui-doc--sideline-pos-y ()
-  "."
   (-> (when (bound-and-true-p lsp-ui-sideline--occupied-lines)
         (-min lsp-ui-sideline--occupied-lines))
       (line-number-at-pos)
@@ -409,8 +406,7 @@ FN is the function to call on click."
       (search-failed nil))))
 
 (defun lsp-ui-doc--render-buffer (string symbol)
-  "Set the BUFFER with STRING.
-SYMBOL."
+  "Set the buffer with STRING."
   (lsp-ui-doc--with-buffer
    (erase-buffer)
    (insert (concat (propertize "\n" 'face '(:height 0.2))
@@ -424,8 +420,7 @@ SYMBOL."
          cursor-type nil)))
 
 (defun lsp-ui-doc--display (symbol string)
-  "Display the documentation on screen.
-SYMBOL STRING."
+  "Display the documentation on screen."
   (if (or (null string)
           (string-empty-p string))
       (lsp-ui-doc--hide-frame)
@@ -465,15 +460,14 @@ SYMBOL STRING."
     (lsp-ui-doc--set-frame nil)))
 
 (defadvice select-window (after lsp-ui-doc--select-window activate)
-  "Delete the child fram if window changes."
+  "Delete the child frame if window changes."
   (lsp-ui-doc--hide-frame))
 
 (defadvice load-theme (after lsp-ui-doc--delete-frame-on-theme-load activate)
-  "Force a frame refresh on theme reload"
+  "Force a frame refresh on theme reload."
   (lsp-ui-doc--delete-frame))
 
 (defun lsp-ui-doc-enable-eldoc ()
-  "."
   (setq-local eldoc-documentation-function 'lsp-ui-doc--eldoc))
 
 (defun lsp-ui-doc--on-delete (frame)
@@ -512,7 +506,7 @@ SYMBOL STRING."
       (setq-local eldoc-documentation-function 'lsp--on-hover)))))
 
 (defun lsp-ui-doc-enable (enable)
-  "ENABLE/disable lsp-ui-doc-mode.
+  "Enable/disable ‘lsp-ui-doc-mode’.
 It is supposed to be called from `lsp-ui--toggle'"
   (lsp-ui-doc-mode (if enable 1 -1)))
 

--- a/lsp-ui-flycheck.el
+++ b/lsp-ui-flycheck.el
@@ -42,7 +42,7 @@
   :link '(info-link "(lsp-ui-flycheck) Customizing"))
 
 (defcustom lsp-ui-flycheck-enable t
-  "Whether or not to enable lsp-ui-flycheck."
+  "Whether or not to enable ‘lsp-ui-flycheck’."
   :type 'boolean
   :group 'lsp-ui)
 

--- a/lsp-ui-imenu.el
+++ b/lsp-ui-imenu.el
@@ -47,7 +47,7 @@
   :link '(info-link "(lsp-ui-imenu) Customizing"))
 
 (defcustom lsp-ui-imenu-enable t
-  "Whether or not to enable lsp-ui-imenu."
+  "Whether or not to enable ‘lsp-ui-imenu’."
   :type 'boolean
   :group 'lsp-ui)
 
@@ -65,17 +65,14 @@
 (defvar imenu--index-alist)
 
 (defun lsp-ui-imenu--pad (s len color &optional no-bar)
-  "S LEN COLOR NO-BAR."
   (let ((n (- len (length s))))
     (propertize (concat (make-string n ?\s) s (unless no-bar " ┃ "))
                 'face `(:foreground ,color))))
 
 (defun lsp-ui-imenu--get-color (index)
-  "INDEX."
   (nth (mod index (length lsp-ui-imenu-colors)) lsp-ui-imenu-colors))
 
 (defun lsp-ui-imenu--make-line (title index padding entry color-index)
-  "TITLE INDEX PADDING ENTRY COLOR-INDEX."
   (let* ((color (lsp-ui-imenu--get-color color-index))
          (prefix (if (and (= index 0) (eq lsp-ui-imenu-kind-position 'left)) title " "))
          (text (concat (lsp-ui-imenu--pad prefix padding color)
@@ -91,12 +88,10 @@
 (defvar-local lsp-ui-imenu-ov nil)
 
 (defun lsp-ui-imenu--make-ov nil
-  "."
   (or (and (overlayp lsp-ui-imenu-ov) lsp-ui-imenu-ov)
       (setq lsp-ui-imenu-ov (make-overlay 1 1))))
 
 (defun lsp-ui-imenu--post-command nil
-  "."
   (when (eobp)
     (forward-line -1))
   (-when-let (padding (get-char-property (point) 'padding))
@@ -122,12 +117,10 @@
 (defvar lsp-ui-imenu--origin nil)
 
 (defun lsp-ui-imenu--put-separator nil
-  "."
   (let ((ov (make-overlay (point) (point))))
     (overlay-put ov 'after-string (propertize "\n" 'face '(:height 0.6)))))
 
 (defun lsp-ui-imenu--put-kind (title padding color-index)
-  "TITLE PADDING COLOR-INDEX."
   (when (eq lsp-ui-imenu-kind-position 'top)
     (let ((ov (make-overlay (point) (point)))
           (color (lsp-ui-imenu--get-color color-index)))
@@ -139,7 +132,6 @@
                (propertize "\n" 'face '(:height 0.3)))))))
 
 (defun lsp-ui-imenu nil
-  "."
   (interactive)
   (setq lsp-ui-imenu--origin (current-buffer))
   (imenu--make-index-alist)
@@ -187,12 +179,10 @@
       (window-resize win 3 t))))
 
 (defun lsp-ui-imenu--kill nil
-  "."
   (interactive)
   (kill-buffer-and-window))
 
 (defun lsp-ui-imenu--jump (direction)
-  "."
   (let ((current (get-text-property (point) 'title)))
     (forward-line direction)
     (while (and current
@@ -201,19 +191,16 @@
       (forward-line direction))))
 
 (defun lsp-ui-imenu--next-kind nil
-  "."
   (interactive)
   (lsp-ui-imenu--jump 1))
 
 (defun lsp-ui-imenu--prev-kind nil
-  "."
   (interactive)
   (lsp-ui-imenu--jump -1)
   (while (not (= (get-text-property (point) 'index) 0))
     (forward-line -1)))
 
 (defun lsp-ui-imenu--go nil
-  "."
   (interactive)
   (let ((marker (get-text-property (point) 'marker)))
     (select-window (get-buffer-window lsp-ui-imenu--origin))
@@ -221,7 +208,6 @@
     (pulse-momentary-highlight-one-line (point) 'next-error)))
 
 (defun lsp-ui-imenu--look nil
-  "."
   (interactive)
   (let ((marker (get-text-property (point) 'marker)))
     (with-selected-window (get-buffer-window lsp-ui-imenu--origin)
@@ -230,7 +216,7 @@
       (pulse-momentary-highlight-one-line (point) 'next-error))))
 
 (defvar lsp-ui-imenu-mode-map nil
-  "Keymap uses with ‘lsp-ui-peek-mode’.")
+  "Keymap for ‘lsp-ui-peek-mode’.")
 (unless lsp-ui-imenu-mode-map
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "q") 'lsp-ui-imenu--kill)

--- a/lsp-ui-peek.el
+++ b/lsp-ui-peek.el
@@ -48,7 +48,7 @@
   :link '(info-link "(lsp-ui-peek) Customizing"))
 
 (defcustom lsp-ui-peek-enable t
-  "Whether or not to enable lsp-ui-peek."
+  "Whether or not to enable ‘lsp-ui-peek’."
   :type 'boolean
   :group 'lsp-ui)
 
@@ -63,8 +63,8 @@
   :group 'lsp-ui-peek)
 
 (defcustom lsp-ui-peek-force-fontify nil
-  "Force to fontify chunks of code (use semantics colors).  WARNING:
-This can heavily slow the processing."
+  "Force to fontify chunks of code (use semantics colors).
+WARNING: This can heavily slow the processing."
   :type 'boolean
   :group 'lsp-ui-peek)
 
@@ -105,9 +105,10 @@ By default, the peek view isn't shown if there is 1 xref."
        :foreground "black"
        :distant-foreground "white"
        :box (:line-width -1 :color "white")))
-  "Face used to highlight the reference/definition.  Do not use box,
-underline or overline prop. If you want to use box, use a negative value for
-its width. Thoses properties deform the whole overlay."
+  "Face used to highlight the reference/definition.
+Do not use box, underline or overline prop.  If you want to use
+box, use a negative value for its width.  Those properties deform
+the whole overlay."
   :group 'lsp-ui-peek)
 
 (defface lsp-ui-peek-header
@@ -118,15 +119,16 @@ its width. Thoses properties deform the whole overlay."
 
 (defface lsp-ui-peek-footer
   '((t :inherit lsp-ui-peek-header))
-  "Face used for the footers. Only the background of this face is used."
+  "Face used for the footers.  Only the background of this face is used."
   :group 'lsp-ui-peek)
 
 (defface lsp-ui-peek-selection
   '((((background light)) :background "grey30" :foreground "white")
     (t :background "white" :foreground "black"))
-  "Face used for the current selection. Do not use box, underline or overline..
- prop. If you want to use box, use a negative value for its width.
-Thoses properties deform the whole overlay."
+  "Face used for the current selection.
+Do not use box, underline or overline prop.  If you want to use
+box, use a negative value for its width.  Those properties
+deform the whole overlay."
   :group 'lsp-ui-peek)
 
 (defvar lsp-ui-peek-expand-function 'lsp-ui-peek--expand-buffer
@@ -165,36 +167,29 @@ It should returns a list of filenames to expand.")
       (run-hooks 'xref-after-return-hook))))
 
 (defmacro lsp-ui-peek--prop (prop &optional string)
-  "PROP STRING."
   `(get-text-property 0 ,prop (or ,string (lsp-ui-peek--get-text-selection) "")))
 
 (defmacro lsp-ui-peek--add-prop (prop &optional string)
-  "PROP STRING."
   `(let ((obj (or ,string (lsp-ui-peek--get-text-selection))))
      (add-text-properties 0 (length obj) ,prop obj)
      obj))
 
 (defun lsp-ui-peek--truncate (len s)
-  "LEN S."
   (if (> (string-width s) len)
       (format "%s.." (substring s 0 (- len 2)))
     s))
 
 (defun lsp-ui-peek--get-text-selection (&optional n)
-  "N."
   (nth (or n lsp-ui-peek--selection)
        (--remove (get-text-property 0 'lsp-ui-peek-hidden it) lsp-ui-peek--list)))
 
 (defun lsp-ui-peek--get-selection ()
-  "."
   (get-text-property 0 'lsp-ui-peek (or (lsp-ui-peek--get-text-selection) "")))
 
 (defun lsp-ui-peek--visual-index ()
-  "."
   (- lsp-ui-peek--selection lsp-ui-peek--offset))
 
 (defun lsp-ui-peek--make-line (index src)
-  "INDEX SRC."
   (-let* (((s1 . s2) src)
           (len-s1 (length s1))
           (len-s2 (length s2))
@@ -221,13 +216,11 @@ It should returns a list of filenames to expand.")
      (propertize "\n" 'face face-right))))
 
 (defun lsp-ui-peek--adjust (width strings)
-  "WIDTH STRINGS."
   (-let* (((s1 . s2) strings))
     (cons (lsp-ui-peek--truncate (- width (1+ lsp-ui-peek-list-width)) s1)
           (lsp-ui-peek--truncate (1- lsp-ui-peek-list-width) s2))))
 
 (defun lsp-ui-peek--make-footer ()
-  "."
   ;; Character-only terminals don't support characters of different height
   (when (display-graphic-p)
     (list
@@ -244,7 +237,6 @@ It should returns a list of filenames to expand.")
       (propertize "\n" 'face '(:height 0.5))))))
 
 (defun lsp-ui-peek--peek-new (src1 src2)
-  "SRC1 SRC2."
   (-let* ((win-width (window-text-width))
           (string (-some--> (-zip-fill "" src1 src2)
                             (--map (lsp-ui-peek--adjust win-width it) it)
@@ -258,13 +250,11 @@ It should returns a list of filenames to expand.")
     (overlay-put ov 'window (get-buffer-window))))
 
 (defun lsp-ui-peek--expand-buffer (files)
-  "FILES."
   (if (--any? (equal (car it) buffer-file-name) files)
       (list buffer-file-name)
     (list (caar files))))
 
 (defun lsp-ui-peek--expand (xrefs)
-  "XREFS."
   (let* ((to-expand (->> (--map (cons (plist-get it :file) (plist-get it :count)) xrefs)
                          (funcall lsp-ui-peek-expand-function)))
          first)
@@ -280,7 +270,7 @@ It should returns a list of filenames to expand.")
 
 (defun lsp-ui-peek--show (xrefs)
   "Create a window to list references/defintions.
-XREFS is a list of list of references/definitions."
+XREFS is a list of references/definitions."
   (setq lsp-ui-peek--win-start (window-start)
         lsp-ui-peek--selection 0
         lsp-ui-peek--offset 0
@@ -308,13 +298,11 @@ XREFS is a list of list of references/definitions."
   (lsp-ui-peek--peek))
 
 (defun lsp-ui-peek--recenter ()
-  "."
   (let ((half-height (/ lsp-ui-peek-peek-height 2)))
     (when (> lsp-ui-peek--selection half-height)
       (setq lsp-ui-peek--offset (- lsp-ui-peek--selection (1- half-height))))))
 
 (defun lsp-ui-peek--fill (min-len list)
-  "MIN-LEN LIST."
   (let ((len (length list)))
     (if (< len min-len)
         (append list (-repeat (- min-len len) ""))
@@ -340,26 +328,22 @@ XREFS is a list of list of references/definitions."
     (lsp-ui-peek--peek-new ref-view list-refs)))
 
 (defun lsp-ui-peek--toggle-text-prop (s)
-  "S."
   (let ((state (lsp-ui-peek--prop 'lsp-ui-peek-hidden s)))
     (lsp-ui-peek--add-prop `(lsp-ui-peek-hidden ,(not state)) s)))
 
 (defun lsp-ui-peek--toggle-hidden (file)
-  "FILE."
   (setq lsp-ui-peek--list
         (--map-when (string= (plist-get (lsp-ui-peek--prop 'lsp-ui-peek it) :file) file)
                     (prog1 it (lsp-ui-peek--toggle-text-prop it))
                     lsp-ui-peek--list)))
 
 (defun lsp-ui-peek--remove-hidden (file)
-  "FILE."
   (setq lsp-ui-peek--list
         (--map-when (string= (plist-get (lsp-ui-peek--prop 'lsp-ui-peek it) :file) file)
                     (prog1 it (lsp-ui-peek--add-prop '(lsp-ui-peek-hidden nil) it))
                     lsp-ui-peek--list)))
 
 (defun lsp-ui-peek--make-ref-line (xref)
-  "XREF."
   (-let* (((&plist :summary summary :line line :file file) xref)
           (string (format "%-3s %s"
                           (propertize (number-to-string (1+ line))
@@ -368,7 +352,6 @@ XREFS is a list of list of references/definitions."
     (lsp-ui-peek--add-prop `(lsp-ui-peek ,xref file ,file) string)))
 
 (defun lsp-ui-peek--insert-xrefs (xrefs filename index)
-  "XREFS FILENAME INDEX."
   (setq lsp-ui-peek--list (--> (lsp-ui-peek--get-xrefs-in-file (cons filename xrefs))
                                (-map 'lsp-ui-peek--make-ref-line it)
                                (-insert-at (1+ index) it lsp-ui-peek--list)
@@ -376,7 +359,6 @@ XREFS is a list of list of references/definitions."
   (lsp-ui-peek--add-prop '(xrefs nil)))
 
 (defun lsp-ui-peek--toggle-file (&optional no-update)
-  "NO-UPDATE."
   (interactive)
   (-if-let* ((xrefs (lsp-ui-peek--prop 'xrefs))
              (filename (lsp-ui-peek--prop 'file))
@@ -391,11 +373,9 @@ XREFS is a list of list of references/definitions."
     (lsp-ui-peek--peek)))
 
 (defun lsp-ui-peek--select (index)
-  "INDEX."
   (setq lsp-ui-peek--selection (+ lsp-ui-peek--selection index)))
 
 (defun lsp-ui-peek--select-next (&optional no-update)
-  "NO-UPDATE."
   (interactive)
   (when (lsp-ui-peek--get-text-selection (1+ lsp-ui-peek--selection))
     (lsp-ui-peek--select 1)
@@ -405,7 +385,6 @@ XREFS is a list of list of references/definitions."
       (lsp-ui-peek--peek))))
 
 (defun lsp-ui-peek--select-prev (&optional no-update)
-  "NO-UPDATE."
   (interactive)
   (when (> lsp-ui-peek--selection 0)
     (lsp-ui-peek--select -1)
@@ -415,7 +394,6 @@ XREFS is a list of list of references/definitions."
     (lsp-ui-peek--peek)))
 
 (defun lsp-ui-peek--select-prev-file ()
-  "."
   (interactive)
   (let ((last-file (lsp-ui-peek--prop 'file)))
     (lsp-ui-peek--select-prev t)
@@ -433,7 +411,6 @@ XREFS is a list of list of references/definitions."
     (lsp-ui-peek--select-next)))
 
 (defun lsp-ui-peek--select-next-file ()
-  "."
   (interactive)
   (-let* ((last-file (lsp-ui-peek--prop 'file))
           (last-selection lsp-ui-peek--selection)
@@ -475,8 +452,7 @@ XREFS is a list of list of references/definitions."
     (funcall fn)))
 
 (defun lsp-ui-peek--goto-xref (&optional x other-window)
-  "Go to a reference/definition.
-X OTHER-WINDOW."
+  "Go to a reference/definition."
   (interactive)
   (-if-let (xref (or x (lsp-ui-peek--get-selection)))
       (-let (((&plist :file file :line line :column column) xref)
@@ -511,12 +487,11 @@ X OTHER-WINDOW."
     (lsp-ui-peek--toggle-file)))
 
 (defun lsp-ui-peek--goto-xref-other-window ()
-  "."
   (interactive)
   (lsp-ui-peek--goto-xref nil t))
 
 (defvar lsp-ui-peek-mode-map nil
-  "Keymap uses with ‘lsp-ui-peek-mode’.")
+  "Keymap for ‘lsp-ui-peek-mode’.")
 (unless lsp-ui-peek-mode-map
   (let ((map (make-sparse-keymap)))
     (suppress-keymap map t)
@@ -546,7 +521,6 @@ X OTHER-WINDOW."
     (lsp-ui-peek--peek-hide)))
 
 (defun lsp-ui-peek--abort ()
-  "."
   (interactive)
   ;; The timer fixes https://github.com/emacs-lsp/lsp-ui/issues/33
   (run-with-idle-timer 0 nil 'lsp-ui-peek--disable))
@@ -561,8 +535,7 @@ X OTHER-WINDOW."
 
 (defun lsp-ui-peek--find-xrefs (input kind &optional request param)
   "Find INPUT references.
-KIND is 'references, 'definitions or a custom kind.
-REQUEST PARAM."
+KIND is ‘references’, ‘definitions’ or a custom kind."
   (setq lsp-ui-peek--kind kind)
   (let ((xrefs (lsp-ui-peek--get-references kind request param)))
     (unless xrefs
@@ -614,8 +587,7 @@ PARAM is the method parameter.  If nil, it default to TextDocumentPositionParams
   (lsp-ui-peek--find-xrefs (symbol-at-point) kind request param))
 
 (defun lsp-ui-peek--extract-chunk-from-buffer (pos start end)
-  "Return the chunk of code pointed to by POS (a Position object)..
-in the current buffer.
+  "Return the chunk of code pointed to by POS (a Position object) in the current buffer.
 START and END are delimiters."
   (let* ((point (lsp--position-to-point pos))
          (inhibit-field-text-motion t)
@@ -651,7 +623,6 @@ LOCATION can be either a LSP Location or SymbolInformation."
           :len (- end start))))
 
 (defun lsp-ui-peek--fontify-buffer (filename)
-  "FILENAME."
   (when lsp-ui-peek-force-fontify
     (unless buffer-file-name
       (make-local-variable 'delay-mode-hooks)
@@ -701,8 +672,7 @@ interface Location {
 
 (defun lsp-ui-peek--get-references (_kind request &optional param)
   "Get all references/definitions for the symbol under point.
-Returns item(s).
-KIND REQUEST PARAM."
+Returns item(s)."
   (-some->> (lsp--send-request (lsp--make-request
                                 request
                                 (or param (lsp--text-document-position-params))))
@@ -712,7 +682,6 @@ KIND REQUEST PARAM."
 (defvar lsp-ui-mode-map)
 
 (defun lsp-ui-peek-enable (enable)
-  "ENABLE."
   (interactive)
   (unless (bound-and-true-p lsp-ui-mode-map)
     (user-error "Please load lsp-ui before trying to enable lsp-ui-peek")))

--- a/lsp-ui-sideline.el
+++ b/lsp-ui-sideline.el
@@ -44,7 +44,7 @@
   :link '(info-link "(lsp-ui-sideline) Customizing"))
 
 (defcustom lsp-ui-sideline-enable t
-  "Whether or not to enable lsp-ui-sideline."
+  "Whether or not to enable ‘lsp-ui-sideline’."
   :type 'boolean
   :group 'lsp-ui)
 
@@ -54,22 +54,22 @@
   :group 'lsp-ui-sideline)
 
 (defcustom lsp-ui-sideline-show-symbol t
-  "Whether to show the symbol on the right of the information"
+  "Whether to show the symbol on the right of the information."
   :type 'boolean
   :group 'lsp-ui-sideline)
 
 (defcustom lsp-ui-sideline-show-hover t
-  "Whether to show hover messages in sideline"
+  "Whether to show hover messages in sideline."
   :type 'boolean
   :group 'lsp-ui-sideline)
 
 (defcustom lsp-ui-sideline-show-flycheck t
-  "Whether to show flycheck messages in sideline"
+  "Whether to show flycheck messages in sideline."
   :type 'boolean
   :group 'lsp-ui-sideline)
 
 (defcustom lsp-ui-sideline-show-code-actions t
-  "Whether to show code actions in sideline"
+  "Whether to show code actions in sideline."
   :type 'boolean
   :group 'lsp-ui-sideline)
 
@@ -234,23 +234,19 @@ CURRENT is non-nil when the point is on the symbol."
      str)))
 
 (defun lsp-ui-sideline--check-duplicate (symbol info)
-  "SYMBOL INFO."
   (not (when lsp-ui-sideline-ignore-duplicate
          (--any (and (string= (overlay-get it 'symbol) symbol)
                      (string= (overlay-get it 'info) info))
                 lsp-ui-sideline--ovs))))
 
 (defun lsp-ui-sideline--margin-width ()
-  "."
   (if fringes-outside-margins right-margin-width 0))
 
 (defun lsp-ui-sideline--window-width ()
-  "."
   (- (window-text-width)
      (lsp-ui-sideline--margin-width)))
 
 (defun lsp-ui-sideline--push-info (symbol line bounds info)
-  "SYMBOL LINE BOUNDS INFO."
   (when (= line (line-number-at-pos))
     (let* ((info (concat (thread-first (gethash "contents" info)
                            lsp-ui-sideline--extract-info
@@ -417,7 +413,7 @@ This does not toggle display of flycheck diagnostics or code actions."
    ))
 
 (defun lsp-ui-sideline-enable (enable)
-  "ENABLE/disable lsp-ui-sideline-mode."
+  "Enable/disable ‘lsp-ui-sideline-mode’."
   (lsp-ui-sideline-mode (if enable 1 -1)))
 
 (provide 'lsp-ui-sideline)

--- a/lsp-ui.el
+++ b/lsp-ui.el
@@ -34,7 +34,7 @@
 ;;; Code:
 
 (defgroup lsp-ui nil
-  "lsp-ui contains a series of useful UI integrations for lsp-mode."
+  "‘lsp-ui’ contains a series of useful UI integrations for ‘lsp-mode’."
   :group 'tools
   :group 'convenience
   :link '(custom-manual "(lsp-ui) Top")
@@ -51,8 +51,8 @@
   (require 'lsp-ui-doc))
 
 (defun lsp-ui--workspace-path (path)
-  "Return the path relative to the workspace.
-If the path is not in the workspace, it returns the original PATH."
+  "Return the PATH relative to the workspace.
+If the PATH is not in the workspace, it returns the original PATH."
   (let* ((root (lsp--workspace-root lsp--cur-workspace))
          (in-workspace (string-prefix-p root path)))
     (if in-workspace
@@ -60,7 +60,6 @@ If the path is not in the workspace, it returns the original PATH."
       path)))
 
 (defun lsp-ui--toggle (enable)
-  "ENABLE."
   (dolist (feature '(lsp-ui-flycheck lsp-ui-peek lsp-ui-sideline lsp-ui-doc))
     (when (featurep feature)
       (let* ((sym (intern-soft (concat (symbol-name feature) "-enable")))
@@ -88,14 +87,15 @@ omitted or nil, and toggle it if ARG is ‘toggle’."
 ;; regex quotes the pattern. The language server likely knows more about how
 ;; to do fuzzy matching.
 (defun lsp-ui-find-workspace-symbol (pattern)
-  "List project-wide symbols matching the query string"
+  "List project-wide symbols matching the query string PATTERN."
   (interactive (list (read-string
                       "workspace/symbol: "
                       nil 'xref--read-pattern-history)))
   (xref--find-xrefs pattern 'apropos pattern nil))
 
 (defun lsp-ui--location< (x y)
-  "Comparator of (filename line column)."
+  "Compares two triples X and Y.
+Both should have the form (FILENAME LINE COLUMN)."
   (if (not (string= (car x) (car y)))
       (string< (car x) (car y))
     (if (not (= (cadr x) (cadr y)))
@@ -103,7 +103,7 @@ omitted or nil, and toggle it if ARG is ‘toggle’."
       (< (caddr x) (caddr y)))))
 
 (defun lsp-ui--reference-triples ()
-  "Returns references in (filename line column) triples."
+  "Return references as a list of (FILENAME LINE COLUMN) triples."
   (let ((refs (lsp--send-request (lsp--make-request
                                   "textDocument/references"
                                   (lsp--make-reference-params)))))


### PR DESCRIPTION
- Add proper symbol quoting.

- Add line breaks where necessary.

- Fix typos.

- Remove empty argument descriptions that describe nothing.  Rather than
  silencing checkdoc, these functions should get proper documentation strings.

- Add some missing punctuation.