### PR TITLE
[lsp-ui-imenu] cleanup overlays when refreshing *lsp-ui-imenu*

### DIFF
--- a/lsp-ui-imenu.el
+++ b/lsp-ui-imenu.el
@@ -137,6 +137,7 @@
         queue)
     (with-current-buffer (get-buffer-create "*lsp-ui-imenu*")
       (setq buffer-read-only nil)
+      (remove-overlays)
       (erase-buffer)
       (let ((padding (or (and (eq lsp-ui-imenu-kind-position 'top) 1)
                          (--> (--filter (imenu--subalist-p it) list)


### PR DESCRIPTION
Without this change, section titles were accumulated
everytime the buffer was updated.