### PR TITLE
[lsp-ui-peek] Wrap textDocument/definition result in a sequence if not already.

### DIFF
--- a/lsp-ui-peek.el
+++ b/lsp-ui-peek.el
@@ -697,6 +697,10 @@ interface Location {
             (seq-group-by it locations)
             (mapcar #'lsp-ui-peek--get-xrefs-list it)))
 
+(defun lsp-ui-peek--to-sequence (maybe-sequence)
+  "If maybe-sequence is not a sequence, wraps it into a single-element sequence."
+  (if (sequencep maybe-sequence) maybe-sequence (list maybe-sequence)))
+
 (defun lsp-ui-peek--get-references (_kind request &optional param)
   "Get all references/definitions for the symbol under point.
 Returns item(s).
@@ -704,6 +708,8 @@ KIND REQUEST PARAM."
   (-some->> (lsp--send-request (lsp--make-request
                                 request
                                 (or param (lsp--text-document-position-params))))
+            ;; Language servers may return a single LOCATION instead of a sequence of them.
+            (lsp-ui-peek--to-sequence)
             (lsp-ui-peek--locations-to-xref-items)
             (-filter 'identity)))
 


### PR DESCRIPTION
Language servers are free to reply to `textDocument/definition` with a single `Location` and PHP language server does. This causes a type error when peeking definitions. This wraps the result into a list if it is not a sequence already.