### PR TITLE
Resolves incompatibility with solarized theme and helm, and reduces slowdowns

### DIFF
--- a/lsp-ui-doc.el
+++ b/lsp-ui-doc.el
@@ -300,7 +300,7 @@ BUFFER is the buffer where the request has been made."
   (when (lsp-ui-doc--get-frame)
     (lsp-ui-doc--with-buffer
      (erase-buffer))
-    (make-frame-invisible (lsp-ui-doc--get-frame))))
+    (lsp-ui-doc--delete-frame)))
 
 (defun lsp-ui-doc--buffer-width ()
   "Calcul the max width of the buffer."


### PR DESCRIPTION
This resolves the incompatibility issue with the solarized theme and helm (#33) and reduces slowdowns after the documentation frame is made invisible. Introduces new (other) slowdowns due to recreating the documentation frame instead of revealing it when documentation is shown.