### PR TITLE
[lsp-ui-doc] Fix doc-string length calculation error

### DIFF
--- a/lsp-ui-doc.el
+++ b/lsp-ui-doc.el
@@ -481,7 +481,7 @@ Use because `string-width' counts invisible characters."
     string))
 
 (defun lsp-ui-doc--inline-faking-frame (doc-strings)
-  (let* ((len-max (length (-max-by (-on '> 'string-width) doc-strings))))
+  (let* ((len-max (-max-by '> (-map 'string-width doc-strings))))
     (setq lsp-ui-doc--inline-width len-max)
     (--map (lsp-ui-doc--inline-padding it len-max) doc-strings)))
 


### PR DESCRIPTION
* Correct length (fixed)

    ```elisp
    (-max-by '> (-map 'string-width '("var str = \"中文\"")))
    ;; => 16
    ```

* Incorrect length (original)

    ```elisp
    (length (-max-by (-on '> 'string-width) '("var str = \"中文\"")))
    ;; => 14
    ```
    When the incorrect length passed to `lsp-ui-doc--inline-padding`，it will triggle an error `concat: Wrong type argument: wholenump, -2`, and freeze the cursor for a while.