### PR TITLE
[lsp-ui-doc] Remove `lsp-ui-doc--remove-invisibles`

### DIFF
--- a/lsp-ui-doc.el
+++ b/lsp-ui-doc.el
@@ -442,15 +442,6 @@ FN is the function to call on click."
   (lsp-ui-doc--with-buffer
    (length (split-string (buffer-string) "\n"))))
 
-;; TODO Optimize this function
-(defun lsp-ui-doc--remove-invisibles (string)
-  "Remove invisible characters in STRING."
-  (let ((res ""))
-    (dotimes (i (length string))
-      (unless (get-text-property i 'invisible string)
-        (setq res (concat res (substring string i (1+ i))))))
-    res))
-
 (defvar-local lsp-ui-doc--inline-width nil)
 
 (defun lsp-ui-doc--inline-window-width nil
@@ -483,11 +474,10 @@ FN is the function to call on click."
 
 (defun lsp-ui-doc--inline-merge (strings)
   (let* ((buffer-strings (-> (lsp-ui-doc--inline-untab strings)
-                             (lsp-ui-doc--remove-invisibles)
                              (split-string "\n")))
          (doc-strings (-> (lsp-ui-doc--with-buffer (buffer-string))
                           (lsp-ui-doc--inline-untab)
-                          (lsp-ui-doc--remove-invisibles)
+                          (substring-no-properties)
                           (split-string "\n")))
          (merged (--> (lsp-ui-doc--inline-faking-frame doc-strings)
                       (-zip-with 'lsp-ui-doc--inline-zip buffer-strings it)


### PR DESCRIPTION
There are serious performance issues with this function, the following is the test:

```elisp
(defmacro with-time-elapse (&rest BODY)
  `(let ((begin-time (current-time)))
     ,@BODY
     (- (float-time (current-time)) (float-time begin-time))))

(let ((pstr (propertize (make-string 1000 ?a) 'face (list :background "#fff")))
      ret1 ret2)
  (message "time1: %f" (with-time-elapse (setq ret1 (lsp-ui-doc--remove-invisibles pstr))))
  (message "time2: %f" (with-time-elapse (setq ret2 (substring-no-properties       pstr))))
  (message "hash1: %s" (md5 ret1))
  (message "hash2: %s" (md5 ret2)))
;; =>
;; time1: 2.557931
;; time2: 0.000004
;; hash1: cabe45dcc9ae5b66ba86600cca6b8ba8
;; hash2: cabe45dcc9ae5b66ba86600cca6b8ba8
```