### PR TITLE
[lsp-ui-doc] Backport string-trim changes from emacs 26.1

### DIFF
--- a/lsp-ui-doc.el
+++ b/lsp-ui-doc.el
@@ -33,6 +33,7 @@
 (require 'dash)
 (require 'dash-functional)
 (require 'markdown-mode)
+(require 'lsp-ui-string-trim)
 
 (defgroup lsp-ui-doc nil
   "Display informations of the current line."
@@ -439,7 +440,7 @@ FN is the function to call on click."
    (erase-buffer)
    (let ((inline-p (lsp-ui-doc--inline-p)))
      (insert (concat (unless inline-p (propertize "\n" 'face '(:height 0.2)))
-                     (string-trim string "[\n]+")
+                     (lsp-ui--string-trim string "[\n]+")
                      (unless inline-p (propertize "\n\n" 'face '(:height 0.3))))))
    (lsp-ui-doc--make-clickable-link)
    (setq-local face-remapping-alist `((header-line lsp-ui-doc-header)))

--- a/lsp-ui-string-trim.el
+++ b/lsp-ui-string-trim.el
@@ -1,0 +1,55 @@
+;;; lsp-ui-string-trim.el --- Lsp-Ui-String-Trim -*- lexical-binding: t -*-
+
+;; Copyright (C) 2017 Sebastien Chapuis
+
+;; Author: Sebastien Chapuis <sebastien@chapu.is>
+;; URL: https://github.com/emacs-lsp/lsp-ui
+;; Keywords: lsp, ui
+
+;;; License
+;;
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3, or (at your option)
+;; any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program; see the file COPYING.  If not, write to
+;; the Free Software Foundation, Inc., 51 Franklin Street, Fifth
+;; Floor, Boston, MA 02110-1301, USA.
+
+;;; Commentary:
+;;
+;; Backport of string-trim* functions from Emacs 26.1
+
+;;; Code:
+
+(defsubst lsp-ui--string-trim-left (string &optional regexp)
+  "Trim STRING of leading string matching REGEXP.
+
+REGEXP defaults to \"[ \\t\\n\\r]+\"."
+  (if (string-match (concat "\\`\\(?:" (or  regexp "[ \t\n\r]+")"\\)") string)
+      (replace-match "" t t string)
+    string))
+
+(defsubst lsp-ui--string-trim-right (string &optional regexp)
+  "Trim STRING of trailing string matching REGEXP.
+
+REGEXP defaults to  \"[ \\t\\n\\r]+\"."
+  (if (string-match (concat "\\(?:" (or regexp "[ \t\n\r]+") "\\)\\'") string)
+      (replace-match "" t t string)
+    string))
+
+(defsubst lsp-ui--string-trim (string &optional trim-left trim-right)
+  "Trim STRING of leading and trailing strings matching TRIM-LEFT and TRIM-RIGHT.
+
+TRIM-LEFT and TRIM-RIGHT default to \"[ \\t\\n\\r]+\"."
+  (lsp-ui--string-trim-left (lsp-ui--string-trim-right string trim-right) trim-left))
+
+(provide 'lsp-ui-string-trim)
+;;; lsp-ui-string-trim.el ends here


### PR DESCRIPTION
On the latest actual release of emacs (25.3), lsp-ui-doc master throws errors when trying to display docs. The cause is `(string-trim string "[\n]+")`: that second parameter will be added in 26.1. Not sure how to best resolve this; I did a straight backport of the functions from current Emacs master.