### PR TITLE
Fix extraction of symbols in lsp-ui-sideline

### DIFF
--- a/lsp-ui-sideline.el
+++ b/lsp-ui-sideline.el
@@ -410,7 +410,7 @@ to the language server."
                                     "textDocument/codeAction"
                                     action-params)
                                    #'lsp-ui-sideline--code-actions))
-        (when lsp-ui-sideline-show-hover
+        (when (and lsp-ui-sideline-show-hover (lsp--capability "hoverProvider"))
           (while (and (<= (point) eol) (< (point) eob))
             (let ((symbol (thing-at-point 'symbol t))
                   (bounds (bounds-of-thing-at-point 'symbol))


### PR DESCRIPTION
As `forward-symbol` places point just _past_ the current symbol and not at the beginning of the next symbol some symbols were missed and several work-around were in place (e.g. checking for "::" or subtracting 1 from the column (even though this is already done by `lsp--cur-column`).

In particular for the following code
```
bool Something::check() { return true; }
```
the previous implementation would place point at the following positions:
```
bool Something::check() { return true; }
^   ^         ^      ^          ^    ^
```
where `Something` would be ignored because of the `(not (looking-at-p "::"))` check.
The new implementation looks at
```
bool Something::check() { return true; }
^    ^          ^         ^      ^
```
and considers all pointed-to symbols.

This pull request also introduces skipping of symbols in comments and checking for the hover capability.