### PR TITLE
Don't save doc childframe with desktop mode

### DIFF
--- a/lsp-ui-doc.el
+++ b/lsp-ui-doc.el
@@ -127,7 +127,8 @@ Only the `background' is used in this face."
     (cursor-type . nil)
     (inhibit-double-buffering . t)
     (drag-internal-border . t)
-    (no-special-glyphs . t))
+    (no-special-glyphs . t)
+    (desktop-dont-save . t))
   "Frame parameters used to create the frame.")
 
 (defvar lsp-ui-doc-render-function nil


### PR DESCRIPTION
Desktop mode sometimes restore the frames out of z-order, but there's no way to push the child frame down the stack, so sometimes after restart I get a blank doc childframe covering my frame controls. This PR makes sure desktop mode ignores the childframe when saving a session.