### PR TITLE
Don't request hover when server cannot handle textDocument/hover

### DIFF
--- a/lsp-ui-doc.el
+++ b/lsp-ui-doc.el
@@ -274,7 +274,8 @@ We don't extract the string that `lps-line' is already displaying."
 (defun lsp-ui-doc--make-request ()
   "Request the documentation to the LS."
   (when (and (bound-and-true-p lsp--cur-workspace)
-             (not (bound-and-true-p lsp-ui-peek-mode)))
+             (not (bound-and-true-p lsp-ui-peek-mode))
+             (lsp--capability "hoverProvider"))
     (if (symbol-at-point)
         (let ((bounds (bounds-of-thing-at-point 'symbol)))
           (unless (equal lsp-ui-doc--bounds bounds)


### PR DESCRIPTION
Related: https://github.com/emacs-lsp/lsp-mode/pull/375