### PR TITLE
[lsp-ui-peek] Generalize lsp-ui-peek-force-fontify to lsp-ui-peek-fontify and add another choice 'on-demand

### DIFF
--- a/lsp-ui.el
+++ b/lsp-ui.el
@@ -46,6 +46,18 @@
 (require 'lsp-ui-imenu)
 (require 'lsp-ui-doc)
 
+(defun lsp-ui-peek--render (major string)
+  (with-temp-buffer
+    (insert string)
+    (delay-mode-hooks
+      (let ((inhibit-message t))
+        (funcall major))
+      (ignore-errors
+        (font-lock-ensure)))
+    (buffer-string))
+  )
+
+
 (defun lsp-ui--workspace-path (path)
   "Return the PATH relative to the workspace.
 If the PATH is not in the workspace, it returns the original PATH."


### PR DESCRIPTION
`'on-demand` fontifies the chunk when the selection changes.

I have indexed compiler-rt with [ccls](https://github.com/MaskRay/ccls) and checked a common identifier `uptr` which has 2000 references (cutoff because of the initialization option [`xref.maxNum`](https://github.com/MaskRay/ccls/blob/master/src/config.h)). It is no slower than `'never` though a bit slower when I trigger `lsp-ui-peek--select-next` continuously. But I think this should be ok.
![](https://ptpb.pw/iD-S.jpg)