### PR TITLE
set left-fringe width to 0 for ui-doc

### DIFF
--- a/lsp-ui-doc.el
+++ b/lsp-ui-doc.el
@@ -579,7 +579,7 @@ HEIGHT is the documentation number of lines."
          (params (append lsp-ui-doc-frame-parameters
                          `((default-minibuffer-frame . ,(selected-frame))
                            (minibuffer . ,(minibuffer-window))
-                           (left-fringe . ,(frame-char-width))
+                           (left-fringe . 0)
                            (background-color . ,(face-background 'lsp-ui-doc-background nil t)))))
          (window (display-buffer-in-child-frame
                   buffer


### PR DESCRIPTION
(left-fringe . (frame-char-width)) was probably used to create a margin for the text as to not mush it up against the frame. However, the margin created will use whatever background color the fringe face is set to, for its background color. Many have this set to black, so you end up with the black left-hand border.

Probably best to set left-fringe width to 0 until a better solution is in place for text padding.