### PR TITLE
lsp-ui-doc: Do not return child frame if it's deleted.

### DIFF
--- a/lsp-ui-doc.el
+++ b/lsp-ui-doc.el
@@ -181,9 +181,10 @@ Because some variables are buffer local.")
   "Set the frame parameter ‘lsp-ui-doc-frame’ to FRAME."
   `(set-frame-parameter nil 'lsp-ui-doc-frame ,frame))
 
-(defmacro lsp-ui-doc--get-frame ()
+(defun lsp-ui-doc--get-frame (&optional include-deleted-frame)
   "Return the child frame."
-  `(frame-parameter nil 'lsp-ui-doc-frame))
+  (let ((frame (frame-parameter nil 'lsp-ui-doc-frame)))
+    (and (frame-live-p frame) frame)))
 
 (defun lsp-ui-doc--make-buffer-name ()
   "Construct the buffer name, it should be unique for each frame."
@@ -563,7 +564,7 @@ HEIGHT is the documentation number of lines."
     (lsp-ui-doc--render-buffer string symbol)
     (if (lsp-ui-doc--inline-p)
         (lsp-ui-doc--inline)
-      (unless (frame-live-p (lsp-ui-doc--get-frame))
+      (unless (lsp-ui-doc--get-frame)
         (lsp-ui-doc--set-frame (lsp-ui-doc--make-frame)))
       (lsp-ui-doc--move-frame (lsp-ui-doc--get-frame))
       (unless (frame-visible-p (lsp-ui-doc--get-frame))


### PR DESCRIPTION
Since the window in the child frame is a dedicated window, it can be killed when
the buffer is killed, resulting in the child frame being deleted. When this
happens, lsp-ui-doc will prevent users from switching to other windows because
the advice on `select-window` fails on operating on the dead frame.

Since there can be other edge cases that may delete the child frame without
notifying lsp-ui-doc, I feel that the most robust solution is always check the
liveness of the child frame before returning it to callers.