### PR TITLE
[lsp-ui-doc] Wrap lines when not using childframes

### DIFF
--- a/lsp-ui-doc.el
+++ b/lsp-ui-doc.el
@@ -234,6 +234,12 @@ MODE is the mode used in the parent frame."
          (funcall render-fn string)
        (with-temp-buffer
          (insert string)
+
+         (if (lsp-ui-doc--inline-p)
+             (progn (let ((fill-column lsp-ui-doc-max-width))
+                      (fill-region (point-min) (point-max)))
+                    (buffer-substring (point-min) (point-max))))
+
          (delay-mode-hooks
            (let ((inhibit-message t))
              (funcall (cond ((and with-lang (string= "text" language)) 'text-mode)

--- a/lsp-ui-doc.el
+++ b/lsp-ui-doc.el
@@ -235,10 +235,9 @@ MODE is the mode used in the parent frame."
        (with-temp-buffer
          (insert string)
 
-         (if (lsp-ui-doc--inline-p)
-             (progn (let ((fill-column lsp-ui-doc-max-width))
-                      (fill-region (point-min) (point-max)))
-                    (buffer-substring (point-min) (point-max))))
+         (when (lsp-ui-doc--inline-p)
+           (let ((fill-column lsp-ui-doc-max-width))
+             (fill-region (point-min) (point-max))))
 
          (delay-mode-hooks
            (let ((inhibit-message t))


### PR DESCRIPTION
When not using childframes, lsp-ui-doc contents should be wrapped according to `lsp-ui-doc-max-width`.

Currently very long lines will result in a overlay that spans the entire width of the window that has truncated lines, eg.
![afa52952-8bd0-48f8-9857-016dce435b5e](https://user-images.githubusercontent.com/224216/46260634-7e7ccc00-c4b6-11e8-8790-2e5c566639d3.jpeg)
This is not helpful as the content is truncated and it also results in an inconsistent look.

Instead I think the overlay should be limited in width according to `lsp-ui-doc-max-wdith` resulting in the following:
![d55c75a3-eaf2-4a00-a465-236229152c72](https://user-images.githubusercontent.com/224216/46260640-a2401200-c4b6-11e8-8d97-b4a2e8cd46d6.jpeg)

I’m quite new to elisp, so please let me know how I can improve my changes if needed. Thanks!