### PR TITLE
margin calculation should allow for end-of-line indicator

### DIFF
--- a/lsp-ui-sideline.el
+++ b/lsp-ui-sideline.el
@@ -247,7 +247,8 @@ CURRENT is non-nil when the point is on the symbol."
          0)
      (if (bound-and-true-p display-line-numbers-mode)
          (+ 2 (line-number-display-width))
-       0)))
+       0)
+     1)) ;; AZ add one for the whitespace end-of-line marker
 
 (defun lsp-ui-sideline--window-width ()
   (- (min (window-text-width) (window-body-width))

--- a/lsp-ui-sideline.el
+++ b/lsp-ui-sideline.el
@@ -248,7 +248,9 @@ CURRENT is non-nil when the point is on the symbol."
      (if (bound-and-true-p display-line-numbers-mode)
          (+ 2 (line-number-display-width))
        0)
-     1)) ;; AZ add one for the whitespace end-of-line marker
+     (if (bound-and-true-p whitespace-mode)
+         1
+       0)))
 
 (defun lsp-ui-sideline--window-width ()
   (- (min (window-text-width) (window-body-width))


### PR DESCRIPTION
In whitespace mode, the end of line marker adds am extra char.

This should probably be detected via the appropriate (if ..), but I have no idea how.

Closes https://github.com/emacs-lsp/lsp-mode/issues/499

My whitespace config is set to

```elisp
 '(whitespace-style
   (quote
    (face trailing tabs spaces lines-tail newline empty indentation space-after-tab space-before-tab tab-mark newline-mark))))
```