### PR TITLE
Make it clear not to use flycheck-mode hooks for lsp

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ To enable the package and its features:
 (add-hook 'lsp-mode-hook 'lsp-ui-mode)
 ```
 
-To enable `flycheck-mode` for a particular LSP client, add the following
+**Note:** Be sure to remove previous `flycheck-mode` hooks you have in your config. They will remove lsp-mode capabilities.
+
+To use FlyCheck **without** lsp for a particular mode, add a hook like this.
 
 ```el
 (add-hook 'XXXXX-mode-hook 'flycheck-mode)


### PR DESCRIPTION
This change makes it crystal clear that you should not use flycheck-mode hooks if you want syntax checking from the lsp.

For a while, I was so confused why my C++ includes were not find even though everything else was working. Turns out I misunderstood the readme. Hopefully this change helps anyone else who got confused by this.