### PR TITLE
Fix disabling lsp-ui-doc-mode

### DIFF
--- a/lsp-ui-doc.el
+++ b/lsp-ui-doc.el
@@ -599,7 +599,7 @@ HOVER is the returned signature information."
     (add-hook 'lsp-on-hover-hook 'lsp-ui-doc--on-hover nil t)
     (add-hook 'delete-frame-functions 'lsp-ui-doc--on-delete nil t))
    (t
-    (remove-hook 'lsp-on-hover-hook 'lsp-ui-doc--on-hover)
+    (remove-hook 'lsp-on-hover-hook 'lsp-ui-doc--on-hover t)
     (remove-hook 'delete-frame-functions 'lsp-ui-doc--on-delete t))))
 
 (defun lsp-ui-doc-enable (enable)


### PR DESCRIPTION
The disable function was not removing the `lsp-ui-doc--on-hover` from the
`lsp-on-hover-hook` because of missing `local` flag.

Otherwise, the doc mode could not be disabled after enabling.