### PR TITLE
[lsp-ui-doc] Fix deleting the child frame if window changes (#224)

### DIFF
--- a/lsp-ui-doc.el
+++ b/lsp-ui-doc.el
@@ -557,8 +557,7 @@ HEIGHT is the documentation number of lines."
 
 (defadvice select-window (after lsp-ui-doc--select-window activate)
   "Delete the child frame if window changes."
-  (unless (equal (ad-get-arg 0) (selected-window))
-    (lsp-ui-doc--hide-frame)))
+  (lsp-ui-doc--hide-frame))
 
 (advice-add 'load-theme :before (lambda (&rest _) (lsp-ui-doc--delete-frame)))
 (add-hook 'window-configuration-change-hook #'lsp-ui-doc--hide-frame)


### PR DESCRIPTION
I'm new to using elisp, so hopefully this is the right way to go about fixing this one!

The defadvice for handling this case currently doesn't work because the condition always evaluates to true when selecting windows (i.e. ad-get-arg 0 and selected-window are always equal) - it looks like the selected window is being compared with itself.

I believe the expected behaviour should be to delete the child frame if a window is selected in general, so a check would be unnecessary.

Fixes #224 