### PR TITLE
Fix same-window logic in select-window advice for doc frame

### DIFF
--- a/lsp-ui-doc.el
+++ b/lsp-ui-doc.el
@@ -678,9 +678,12 @@ before, or if the new window is the minibuffer."
   (let ((initial-window (selected-window)))
     (prog1 ad-do-it
       (when (lsp-ui-doc--visible-p)
-        (let ((current-window (selected-window)))
+        (let* ((current-window (selected-window))
+               (doc-buffer (get-buffer (lsp-ui-doc--make-buffer-name))))
           (unless (or (window-minibuffer-p current-window)
-                      (equal current-window initial-window))
+                      (equal current-window initial-window)
+                      (and doc-buffer
+                           (equal (window-buffer initial-window) doc-buffer)))
             (lsp-ui-doc--hide-frame)))))))
 
 (advice-add 'load-theme :before (lambda (&rest _) (lsp-ui-doc--delete-frame)))

--- a/lsp-ui-doc.el
+++ b/lsp-ui-doc.el
@@ -665,10 +665,23 @@ HEIGHT is the documentation number of lines."
     (delete-frame frame)
     (lsp-ui-doc--set-frame nil)))
 
-(defadvice select-window (after lsp-ui-doc--select-window activate)
-  "Delete the child frame if window changes."
-  (unless (equal (ad-get-arg 0) (selected-window))
-    (lsp-ui-doc--hide-frame)))
+(defun lsp-ui-doc--visible-p ()
+  "Return whether the LSP UI doc is visible"
+  (or (overlayp lsp-ui-doc--inline-ov)
+      (and (lsp-ui-doc--get-frame)
+           (frame-visible-p (lsp-ui-doc--get-frame)))))
+
+(defadvice select-window (around lsp-ui-doc--select-window activate)
+  "Delete the child frame if currently selected window changes.
+Does nothing if the newly-selected window is the same window as
+before, or if the new window is the minibuffer."
+  (let ((initial-window (selected-window)))
+    (prog1 ad-do-it
+      (when (lsp-ui-doc--visible-p)
+        (let ((current-window (selected-window)))
+          (unless (or (window-minibuffer-p current-window)
+                      (equal current-window initial-window))
+            (lsp-ui-doc--hide-frame)))))))
 
 (advice-add 'load-theme :before (lambda (&rest _) (lsp-ui-doc--delete-frame)))
 (add-hook 'window-configuration-change-hook #'lsp-ui-doc--hide-frame)


### PR DESCRIPTION
This PR is a fix for #224, preserving (what I believe is) the intent behind the change in #89: To hide the doc view only if the currently-selected window is no longer the one that the doc view is attached to.

The [original defadvice](https://github.com/emacs-lsp/lsp-ui/blob/df3681b6a578a314374a8d689675aa60ad4afa6e/lsp-ui-doc.el#L670) from #89 was subtly not-quite-right (causing #224) by being an `'after` advice: The advice checked whether `(selected-window)` was the same as the one selected, which _after_ `select-window` had run, was always the case: the `unless` never triggered, always preventing the frame from hiding.

With this PR, I hope to change the check so it is more meaningful, by making the advice an `'around` class, and checking what the values of the selected window are before and after `select-window` ran.

Further, this change prevents the doc frame from hiding if the newly-selected window is the minibuffer (which might be nice for things like `go-rename` and other tools that query for things, where someone might want to use documentation as a reference).