### PR TITLE
[lsp-ui-doc] Round xwidget-resize args, fixes #251.

### DIFF
--- a/lsp-ui-doc.el
+++ b/lsp-ui-doc.el
@@ -385,7 +385,9 @@ We don't extract the string that `lps-line' is already displaying."
       (lsp-ui-doc--line-height)))
 
 (defun lsp-ui-doc--webkit-resize-callback (size)
-  (xwidget-resize (lsp-ui-doc--webkit-get-xwidget) (aref size 0) (aref size 1))
+  (let ((offset-width (round (aref size 0)))
+        (offset-height (round (aref size 1))))
+    (xwidget-resize (lsp-ui-doc--webkit-get-xwidget) offset-width offset-height))
   (lsp-ui-doc--move-frame (lsp-ui-doc--get-frame)))
 
 (defun lsp-ui-doc--resize-buffer ()


### PR DESCRIPTION
Emacs function on the C-side:
https://github.com/emacs-mirror/emacs/blame/5c2563a/src/xwidget.c#L782