### PR TITLE
[lsp-ui-doc] hide info popup during editing and when point moves

### DIFF
--- a/lsp-ui-doc.el
+++ b/lsp-ui-doc.el
@@ -711,6 +711,7 @@ HOVER is the returned signature information."
   "Save the buffer during `pre-command-hook' so that
 `post-command-hook' can check if the buffer is different and
 cleanup the hover state.")
+(defvar lsp-ui-doc--line-saved nil)
 
 (defun lsp-ui-doc--cleanup-hover-state ()
   "Unset state used by hover/eldoc."
@@ -723,6 +724,7 @@ cleanup the hover state.")
 Hide the information popup if the point moves out of the range
 concerned by the hover."
   (setq lsp-ui-doc--command-saved-buffer (current-buffer))
+  (setq lsp-ui-doc--line-saved (line-number-at-pos))
   (unless (and lsp--hover-saved-bounds
                (lsp--point-in-bounds-p lsp--hover-saved-bounds))
     (lsp-ui-doc--cleanup-hover-state)))
@@ -738,7 +740,8 @@ cleanup the hover state of the original buffer."
              (not (eq (current-buffer) lsp-ui-doc--command-saved-buffer)))
     (with-current-buffer lsp-ui-doc--command-saved-buffer
       (lsp-ui-doc--cleanup-hover-state)))
-  (unless (and lsp--hover-saved-bounds
+  (unless (and (eq (line-number-at-pos) lsp-ui-doc--line-saved)
+               lsp--hover-saved-bounds
                (lsp--point-in-bounds-p lsp--hover-saved-bounds))
     (lsp-ui-doc--cleanup-hover-state)))
 

--- a/lsp-ui-doc.el
+++ b/lsp-ui-doc.el
@@ -701,11 +701,38 @@ before, or if the new window is the minibuffer."
 (defun lsp-ui-doc--on-hover (hover)
   "Handler for `lsp-on-hover-hook'.
 HOVER is the returned signature information."
+  (remove-overlays nil nil 'lsp-ui-doc 'lsp-hover)
   (--if-let (-some->> hover (gethash "contents"))
       (lsp-ui-doc--display (thing-at-point 'symbol t)
                            (lsp-ui-doc--extract it))
     (eldoc-message nil)
+    (lsp-ui-doc--hide-frame))
+  (--if-let (-some->> hover (gethash "range"))
+      (let* ((start (gethash "start" it))
+             (end (gethash "end" it))
+             (overlay (make-overlay (lsp--position-to-point start)
+                                    (lsp--position-to-point end))))
+        (overlay-put overlay 'lsp-ui-doc 'lsp-hover))))
+
+(defun lsp-ui-doc--on-overlay-p ()
+  "Return whether point is on a `lsp-ui-doc' overlay."
+  (cl-find-if (lambda (el)
+                (eq (overlay-get el 'lsp-ui-doc) 'lsp-hover))
+              (overlays-at (point))))
+
+(defun lsp-ui-doc--on-post-command ()
+  "Handler for `post-command-hook'.
+Hide the information popup if the point moves out of the symbol
+concerned by the hover."
+  (unless (lsp-ui-doc--on-overlay-p)
+    (remove-overlays nil nil 'lsp-ui-doc 'lsp-hover)
     (lsp-ui-doc--hide-frame)))
+
+(defun lsp-ui-doc--on-change (_beg _end)
+  "Handler for `before-change-functions'.
+Hide the information popup."
+  (remove-overlays nil nil 'lsp-ui-doc 'lsp-hover)
+  (lsp-ui-doc--hide-frame))
 
 (define-minor-mode lsp-ui-doc-mode
   "Minor mode for showing hover information in child frame."
@@ -725,10 +752,14 @@ HOVER is the returned signature information."
         (push '(lsp-ui-doc-frame . :never) frameset-filter-alist)))
 
     (add-hook 'lsp-on-hover-hook 'lsp-ui-doc--on-hover nil t)
-    (add-hook 'delete-frame-functions 'lsp-ui-doc--on-delete nil t))
+    (add-hook 'delete-frame-functions 'lsp-ui-doc--on-delete nil t)
+    (add-hook 'post-command-hook 'lsp-ui-doc--on-post-command nil t)
+    (add-hook 'before-change-functions 'lsp-ui-doc--on-change nil t))
    (t
     (remove-hook 'lsp-on-hover-hook 'lsp-ui-doc--on-hover t)
-    (remove-hook 'delete-frame-functions 'lsp-ui-doc--on-delete t))))
+    (remove-hook 'delete-frame-functions 'lsp-ui-doc--on-delete t)
+    (remove-hook 'post-command-hook 'lsp-ui-doc--on-post-command t)
+    (remove-hook 'before-change-functions 'lsp-ui-doc--on-change t))))
 
 (defun lsp-ui-doc-enable (enable)
   "Enable/disable ‘lsp-ui-doc-mode’.


### PR DESCRIPTION
It is very inconvenient to use lsp-ui-doc with the popup at point because it doesn't disappear until the next call to hover. It means that the point can end up behind the popup or that the popup will hide some code will typing.

This PR solves the issue by relying on two hooks: post-command-hook and before-change-functions. It tries to be smart to avoid flickering of the popup. The popup is hidden only when the point is moved out of the range concerned by the hover.

I guess that this behavior should be made optional, for all the people who like to keep the child frame alive or those who have the doc inline. It is not clear how I should do that.