### PR TITLE
Do not enable/disable imenu in lsp-ui-imenu-enable

### DIFF
--- a/lsp-ui-imenu.el
+++ b/lsp-ui-imenu.el
@@ -324,12 +324,8 @@ Return the updated COLOR-INDEX."
 (define-derived-mode lsp-ui-imenu-mode special-mode "lsp-ui-imenu"
   "Mode showing imenu entries.")
 
-(defun lsp-ui-imenu-enable (enable)
-  (if enable
-      (lsp-enable-imenu)
-    (when (eq imenu-create-index-function 'lsp--imenu-create-index)
-      (setq imenu-create-index-function
-            'imenu-default-create-index-function))))
+(defun lsp-ui-imenu-enable (_enable)
+  )
 
 (provide 'lsp-ui-imenu)
 ;;; lsp-ui-imenu.el ends here


### PR DESCRIPTION
Rationale:

- lsp-imenu-enable should be managed by lsp-mode or the user (see https://github.com/emacs-lsp/lsp-mode/issues/729 )
- lsp-ui-imenu works with default handler as well