### PR TITLE
Add Terminal Friendly Bindings For Imenu

### DIFF
--- a/lsp-ui-imenu.el
+++ b/lsp-ui-imenu.el
@@ -319,6 +319,8 @@ Return the updated COLOR-INDEX."
     (define-key map (kbd "<left>") 'lsp-ui-imenu--prev-kind)
     (define-key map (kbd "<return>") 'lsp-ui-imenu--view)
     (define-key map (kbd "<M-return>") 'lsp-ui-imenu--visit)
+    (define-key map (kbd "RET") 'lsp-ui-imenu--view)
+    (define-key map (kbd "M-RET") 'lsp-ui-imenu--visit)
     (setq lsp-ui-imenu-mode-map map)))
 
 (define-derived-mode lsp-ui-imenu-mode special-mode "lsp-ui-imenu"


### PR DESCRIPTION
The key binding `<return>` only binds to return in the graphical mode of emacs. If emacs is running in the terminal we want to use `RET` instead.