### PR TITLE
lsp-ui-sideline-apply-code-actions: Directly apply in case of just one option

### DIFF
--- a/lsp-ui-sideline.el
+++ b/lsp-ui-sideline.el
@@ -347,13 +347,7 @@ CURRENT is non-nil when the point is on the symbol."
   (interactive)
   (unless lsp-ui-sideline--code-actions
     (user-error "No code actions on the current line"))
-  (let* ((actions lsp-ui-sideline--code-actions)
-         (title (completing-read "Apply: " (--map (gethash "title" it) actions)
-                                 nil t))
-         (action (--first (equal (gethash "title" it) title) actions)))
-    (unless action
-      (error "Fail to apply action"))
-    (lsp-execute-code-action action)))
+  (lsp-execute-code-action (lsp--select-action lsp-ui-sideline--code-actions)))
 
 (defun lsp-ui-sideline--code-actions (actions bol eol)
   "Show code ACTIONS."


### PR DESCRIPTION
The function used to prompt for the action to apply, even if there was just one
option for the current line.

As far as I can tell there was no other way to just "apply the fixit that you see in the sideline" directly, apart from clicking on it, which I find inconvenient.