### PR TITLE
Fix hover not rendering simple MarkedString as Markdown

### DIFF
--- a/lsp-ui-doc.el
+++ b/lsp-ui-doc.el
@@ -261,7 +261,7 @@ CONTENTS can be differents type of values:
 MarkedString | MarkedString[] | MarkupContent (as defined in the LSP).
 We don't extract the string that `lps-line' is already displaying."
   (cond
-   ((stringp contents) contents)
+   ((stringp contents) (lsp-ui-doc--extract-marked-string contents)) ;; MarkedString
    ((sequencep contents) ;; MarkedString[]
     (mapconcat 'lsp-ui-doc--extract-marked-string
                (lsp-ui-doc--filter-marked-string contents)


### PR DESCRIPTION
According to LSP, when contents is a simple string, it is
still a MarkedString and should be rendered as Markdown
https://microsoft.github.io/language-server-protocol/specification#textDocument_hover

in ex. elixir-ls sends a simple string in contents as its docs are always markdown.