### PR TITLE
Fix ability to turn off doc comments

### DIFF
--- a/lsp-ui-doc.el
+++ b/lsp-ui-doc.el
@@ -730,6 +730,7 @@ before, or if the new window is the minibuffer."
     (add-hook 'post-command-hook 'lsp-ui-doc--make-request nil t)
     (add-hook 'delete-frame-functions 'lsp-ui-doc--on-delete nil t))
    (t
+    (lsp-ui-doc-hide)
     (remove-hook 'post-command-hook 'lsp-ui-doc--make-request t)
     (remove-hook 'delete-frame-functions 'lsp-ui-doc--on-delete t))))
 


### PR DESCRIPTION
If doc comments, the doc shown at the top of the buffer, is present and you turn off doc comments
via (lsp-ui-doc-enable nil), the comments are now removed.