### PR TITLE
Fix fringe color in lsp-ui-doc frame

### DIFF
--- a/lsp-ui-doc.el
+++ b/lsp-ui-doc.el
@@ -624,6 +624,7 @@ HEIGHT is the documentation number of lines."
     (set-window-dedicated-p window t)
     (redirect-frame-focus frame (frame-parent frame))
     (set-face-background 'internal-border lsp-ui-doc-border frame)
+    (set-face-background 'fringe nil frame)
     (run-hook-with-args 'lsp-ui-doc-frame-hook frame window)
     (when lsp-ui-doc-use-webkit
       (define-key (current-global-map) [xwidget-event]


### PR DESCRIPTION
Themes that set a background color for the fringe look weird as that color is also used for the fringe inside the lsp-ui-doc frame. Just setting it to `nil` in the frame is enough to go back to something normal.

Fixes #151, #157 and maybe #297.

---
Examples with the Zenburn theme:

- without this patch:
    ![2019-10-16-18_17_36](https://user-images.githubusercontent.com/64833/66938554-a9927900-f041-11e9-906c-0f5d1180650c.png)
- with this patch:
    ![2019-10-16-18_18_00](https://user-images.githubusercontent.com/64833/66938591-bc0cb280-f041-11e9-9e51-71b459a47f28.png)
    