### PR TITLE
Do not hover document after lsp-ui-doc-hide

### DIFF
--- a/lsp-ui-doc.el
+++ b/lsp-ui-doc.el
@@ -644,7 +644,8 @@ HEIGHT is the documentation number of lines."
 
 (defun lsp-ui-doc--make-request nil
   "Request the documentation to the LS."
-  (when (and (not (bound-and-true-p lsp-ui-peek-mode))
+  (when (and (not (eq this-command 'lsp-ui-doc-hide))
+             (not (bound-and-true-p lsp-ui-peek-mode))
              (lsp--capability "hoverProvider"))
     (-if-let (bounds (or (and (symbol-at-point) (bounds-of-thing-at-point 'symbol))
                          (and (looking-at "[[:graph:]]") (cons (point) (1+ (point))))))


### PR DESCRIPTION
so that child frame will not be shown just after hidden.

fixes #327