### PR TITLE
add frame-left-or-right-other for lsp-ui-alignment

### DIFF
--- a/lsp-ui-doc.el
+++ b/lsp-ui-doc.el
@@ -71,6 +71,7 @@
 (defcustom lsp-ui-doc-alignment 'frame
   "How to align the doc."
   :type '(choice (const :tag "Frame" frame)
+                 (const :tag "Other (left or right) side of frame" frame-left-or-right-other)
                  (const :tag "Window" window))
   :group 'lsp-ui-doc)
 
@@ -415,19 +416,32 @@ START-Y is the position y of the current window."
           (char-h (frame-char-height))
           (height (min (- (* lsp-ui-doc-max-height char-h) (/ char-h 2)) height))
           (frame-right (pcase lsp-ui-doc-alignment
-                         ('frame (frame-pixel-width))
-                         ('window right)))
-          (frame-resize-pixelwise t))
+                         ('window right)
+                         (_ (frame-pixel-width))))
+          (frame-resize-pixelwise t)
+          ((window-left-edge window-top-edge window-right-edge _) (window-absolute-pixel-edges))
+          (window-left-right-center (/ (+ window-left-edge window-right-edge) 2))
+          ((frame-left-edge frame-top-edge frame-right-edge _) (frame-edges))
+          (frame-left-right-center (/ (+ frame-left-edge frame-right-edge) 2)))
     (set-frame-size frame width height t)
     (if (eq lsp-ui-doc-position 'at-point)
         (lsp-ui-doc--mv-at-point frame height left top)
       (set-frame-position frame
-                          (max (- frame-right width 10 (frame-char-width)) 10)
+                          (if (and (eq lsp-ui-doc-alignment 'frame-left-or-right-other)
+                                   (> window-left-right-center frame-left-right-center))
+                              10
+                            (max (- frame-right width 10 (frame-char-width)) 10))
                           (pcase lsp-ui-doc-position
-                            ('top (+ top 10))
-                            ('bottom (- (lsp-ui-doc--line-height 'mode-line)
-                                        height
-                                        10)))))))
+                            ('top (pcase lsp-ui-doc-alignment
+                                    ('window (+ top 10))
+                                    (_ 10)))
+                            ('bottom (pcase lsp-ui-doc-alignment
+                                       ('window (- (+ (lsp-ui-doc--line-height 'mode-line) (- window-top-edge frame-top-edge))
+                                                   height
+                                                   10))
+                                       (_ (- (frame-pixel-height)
+                                             height
+                                             10)))))))))
 
 (defun lsp-ui-doc--visit-file (filename)
   "Visit FILENAME in the parent frame."


### PR DESCRIPTION
I want lsp-ui-doc to not cover the code I'm currently editing, so I added an option `frame-left-or-right-other` to `lsp-ui-alignment`, which checks whether the current window is relative "left" or "right" in the frame (by looking at wether the center of the window is to the left or right of the frame).

I also changed the placement of the top of the doc frame, to make it relative to window only when `...alignment` is set to `window`. Otherwise it's relative to the frame.

During the change of the top position, I fixed a small bug, where the mode-line's Y coordinate is coded `(lsp-ui-doc--line-height 'mode-line)`, which is relative to window top, but not frame top. Now it's corrected to `(+ (lsp-ui-doc--line-height 'mode-line) (- window-top-edge frame-top-edge))`