### PR TITLE
Avoid the tab key indenting elements in lsp-ui-imenu

### DIFF
--- a/lsp-ui-imenu.el
+++ b/lsp-ui-imenu.el
@@ -243,7 +243,7 @@ Return the updated COLOR-INDEX."
              (grouped-by-subs (-partition-by 'imenu--subalist-p list))
              (color-index 0)
              (bars (make-bool-vector lsp-ui-imenu--max-bars t))
-             buffer-read-only)
+             (inhibit-read-only t))
         (remove-overlays)
         (erase-buffer)
         (dolist (group grouped-by-subs)


### PR DESCRIPTION
Fixes #335 

The correct way to add content to a buffer in a mode derived from the
read-only special-mode is to create a local binding of
inhibit-read-only set to t.