### PR TITLE
Should filter CR before displaying it to either sidebar or doc

### DIFF
--- a/lsp-ui-doc.el
+++ b/lsp-ui-doc.el
@@ -669,8 +669,12 @@ BUFFER is the buffer where the request has been made."
         (setq lsp-ui-doc--timer
               (run-with-idle-timer
                lsp-ui-doc-delay nil
-               (lambda nil (lsp-ui-doc--display
-                            (thing-at-point 'symbol t) (lsp-ui-doc--extract (gethash "contents" hover)))))))
+               (lambda nil
+                 (lsp-ui-doc--display
+                  (thing-at-point 'symbol t)
+                  (->> (gethash "contents" hover)
+                       lsp-ui-doc--extract
+                       (replace-regexp-in-string "\r" "")))))))
     (lsp-ui-doc--hide-frame)))
 
 (defun lsp-ui-doc--delete-frame ()

--- a/lsp-ui-sideline.el
+++ b/lsp-ui-sideline.el
@@ -278,9 +278,10 @@ CURRENT is non-nil when the point is on the symbol."
 (defun lsp-ui-sideline--push-info (symbol tag bounds info bol eol)
   (when (and (= tag (lsp-ui-sideline--calculate-tag))
              (not (lsp-ui-sideline--stop-p)))
-    (let* ((info (concat (thread-first (gethash "contents" info)
-                           lsp-ui-sideline--extract-info
-                           lsp-ui-sideline--format-info)))
+    (let* ((info (concat (->> (gethash "contents" info)
+                             lsp-ui-sideline--extract-info
+                             lsp-ui-sideline--format-info
+                             (replace-regexp-in-string "\r" ""))))
            (current (and (>= (point) (car bounds)) (<= (point) (cdr bounds)))))
       (when (and (> (length info) 0)
                  (lsp-ui-sideline--check-duplicate symbol info))


### PR DESCRIPTION
Some language server are returning the document including CR characters, we should filter it out since it's annoying and does nothing even if presented.
Part of code refactor from emacs-lsp/lsp-mode#1190