### PR TITLE
Use -some->> to avoid calling (replace-regexp-in-string) with nil

### DIFF
--- a/lsp-ui-doc.el
+++ b/lsp-ui-doc.el
@@ -672,9 +672,9 @@ BUFFER is the buffer where the request has been made."
                (lambda nil
                  (lsp-ui-doc--display
                   (thing-at-point 'symbol t)
-                  (->> (gethash "contents" hover)
-                       lsp-ui-doc--extract
-                       (replace-regexp-in-string "\r" "")))))))
+                  (-some->> (gethash "contents" hover)
+                    lsp-ui-doc--extract
+                    (replace-regexp-in-string "\r" "")))))))
     (lsp-ui-doc--hide-frame)))
 
 (defun lsp-ui-doc--delete-frame ()

--- a/lsp-ui-sideline.el
+++ b/lsp-ui-sideline.el
@@ -278,10 +278,10 @@ CURRENT is non-nil when the point is on the symbol."
 (defun lsp-ui-sideline--push-info (symbol tag bounds info bol eol)
   (when (and (= tag (lsp-ui-sideline--calculate-tag))
              (not (lsp-ui-sideline--stop-p)))
-    (let* ((info (concat (->> (gethash "contents" info)
-                             lsp-ui-sideline--extract-info
-                             lsp-ui-sideline--format-info
-                             (replace-regexp-in-string "\r" ""))))
+    (let* ((info (concat (-some->> (gethash "contents" info)
+                           lsp-ui-sideline--extract-info
+                           lsp-ui-sideline--format-info
+                           (replace-regexp-in-string "\r" ""))))
            (current (and (>= (point) (car bounds)) (<= (point) (cdr bounds)))))
       (when (and (> (length info) 0)
                  (lsp-ui-sideline--check-duplicate symbol info))


### PR DESCRIPTION
Fixes #343 