### PR TITLE
Fix the error of passing a hash-table when string is expected

### DIFF
--- a/lsp-ui-doc.el
+++ b/lsp-ui-doc.el
@@ -280,10 +280,11 @@ We don't extract the string that `lps-line' is already displaying."
                ))
    ;; when we get markdown contents, render using emacs gfm-view-mode / markdown-mode
    ((string= (gethash "kind" contents) "markdown") ;; Markdown MarkupContent
-    (lsp-ui-doc--extract-marked-string contents "markdown"))
+    (lsp-ui-doc--extract-marked-string (gethash "value" contents) "markdown"))
    ((gethash "kind" contents) (gethash "value" contents)) ;; Plaintext MarkupContent
    ((gethash "language" contents) ;; MarkedString
-    (lsp-ui-doc--extract-marked-string contents))))
+    (lsp-ui-doc--extract-marked-string (gethash "value" contents)
+                                       (gethash "language" contents)))))
 
 (defun lsp-ui-doc--webkit-run-xwidget ()
   "Launch embedded WebKit instance."


### PR DESCRIPTION
MarkupContent is represented as a hash-table in lsp-ui. When its
content is extracted the specific values of the hash table need to be
extracted first.  Currently the table is passed without extracting the
value string. This PR fixes that.