### PR TITLE
Issue #347 If `lsp-ui-flycheck-live-reporting` is nil, respect `flycheck-check-syntax-automatically`

### DIFF
--- a/lsp-ui-flycheck.el
+++ b/lsp-ui-flycheck.el
@@ -225,7 +225,9 @@ See https://github.com/emacs-lsp/lsp-mode."
 ;; FIXME: Provide a way to disable lsp-ui-flycheck
 (defun lsp-ui-flycheck-enable (_)
   "Enable flycheck integration for the current buffer."
-  (setq-local lsp-ui-flycheck--save-mode (memq 'save flycheck-check-syntax-automatically))
+  (setq-local lsp-ui-flycheck--save-mode
+	       (or (memq 'save flycheck-check-syntax-automatically)
+		   lsp-ui-flycheck--save-mode))
   (setq-local flycheck-check-syntax-automatically nil)
   (setq-local flycheck-checker 'lsp-ui)
   (lsp-ui-flycheck-add-mode major-mode)

--- a/lsp-ui-flycheck.el
+++ b/lsp-ui-flycheck.el
@@ -58,6 +58,7 @@ If nil, diagnostics will be reported according to `flycheck-check-syntax-automat
   :group 'lsp-ui-flycheck)
 
 (defvar-local lsp-ui-flycheck-list--buffer nil)
+(defvar-local lsp-ui-flycheck--save-mode nil)
 
 (defun lsp-ui-flycheck-list--post-command ()
   (when (eobp)
@@ -215,14 +216,16 @@ See https://github.com/emacs-lsp/lsp-mode."
     (flycheck-add-mode 'lsp-ui mode)))
 
 (defun lsp-ui-flycheck--report nil
+  "This callback is invoked when new diagnostics are received from the language server.  Invoke flycheck-buffer to update the display of errors if flycheck-mode is on and we are live reporting or we are in save-mode and the buffer is not modified."
   (and flycheck-mode
        (or lsp-ui-flycheck-live-reporting
-	   (not (buffer-modified-p)))
+	   (and lsp-ui-flycheck--save-mode (not (buffer-modified-p))))
        (flycheck-buffer)))
 
 ;; FIXME: Provide a way to disable lsp-ui-flycheck
 (defun lsp-ui-flycheck-enable (_)
   "Enable flycheck integration for the current buffer."
+  (setq-local lsp-ui-flycheck--save-mode (memq 'save flycheck-check-syntax-automatically))
   (setq-local flycheck-check-syntax-automatically nil)
   (setq-local flycheck-checker 'lsp-ui)
   (lsp-ui-flycheck-add-mode major-mode)

--- a/lsp-ui-flycheck.el
+++ b/lsp-ui-flycheck.el
@@ -216,14 +216,14 @@ See https://github.com/emacs-lsp/lsp-mode."
 
 (defun lsp-ui-flycheck--report nil
   (and flycheck-mode
-       lsp-ui-flycheck-live-reporting
+       (or lsp-ui-flycheck-live-reporting
+	   (not (buffer-modified-p)))
        (flycheck-buffer)))
 
 ;; FIXME: Provide a way to disable lsp-ui-flycheck
 (defun lsp-ui-flycheck-enable (_)
   "Enable flycheck integration for the current buffer."
-  (when lsp-ui-flycheck-live-reporting
-    (setq-local flycheck-check-syntax-automatically nil))
+  (setq-local flycheck-check-syntax-automatically nil)
   (setq-local flycheck-checker 'lsp-ui)
   (lsp-ui-flycheck-add-mode major-mode)
   (add-to-list 'flycheck-checkers 'lsp-ui)


### PR DESCRIPTION
Changes in `lsp-ui-flycheck` in order to support three configurations:

1. `lsp-ui-flycheck-live-reporting` is not `nil`:
    update errors after every diagnostic report

2. `lsp-ui-flycheck-live-reporting` is `nil` and `flycheck-check-syntax-automatically` contains `'save`:
    update errors after a diagnostic report is the buffer is unmodified

3. `lsp-ui-flycheck-live-reporting` is `nil` and `flycheck-check-syntax-automatically` does not contain `'save`:
    never update errors
