### PR TITLE
Avoid removing blank lines when formatting docs

### DIFF
--- a/lsp-ui-doc.el
+++ b/lsp-ui-doc.el
@@ -239,7 +239,7 @@ Because some variables are buffer local.")
   "Formats STRING for inline rendering."
   (mapconcat (lambda (line)
                (lsp-ui-doc--inline-wrapped-line (string-trim-right line)))
-             (split-string string "[\n\v\f\r]+")
+             (split-string string "[\n\v\f\r]")
              "\n"))
 
 (defun lsp-ui-doc--extract-marked-string (marked-string &optional language)


### PR DESCRIPTION
* lsp-ui-doc.el (lsp-ui-doc--inline-formatted-string): Some docs use
several line ending characters to separate paragraphs. We need to
respect those in `split-string'.