### PR TITLE
lsp-ui-doc: Delay request instead of delaying display

### DIFF
--- a/lsp-ui-doc.el
+++ b/lsp-ui-doc.el
@@ -665,9 +665,15 @@ HEIGHT is the documentation number of lines."
     (-if-let (bounds (or (and (symbol-at-point) (bounds-of-thing-at-point 'symbol))
                          (and (looking-at "[[:graph:]]") (cons (point) (1+ (point))))))
         (unless (equal lsp-ui-doc--bounds bounds)
-          (lsp--send-request-async
-           (lsp--make-request "textDocument/hover" (lsp--text-document-position-params))
-           (lambda (hover) (lsp-ui-doc--callback hover bounds (current-buffer)))))
+          (lsp-ui-doc--hide-frame)
+          (and lsp-ui-doc--timer (cancel-timer lsp-ui-doc--timer))
+          (setq lsp-ui-doc--timer
+                (run-with-idle-timer
+                 lsp-ui-doc-delay nil
+                 (lambda nil
+                   (lsp--send-request-async
+                    (lsp--make-request "textDocument/hover" (lsp--text-document-position-params))
+                    (lambda (hover) (lsp-ui-doc--callback hover bounds (current-buffer))))))))
       (lsp-ui-doc--hide-frame))))
 
 (defun lsp-ui-doc--callback (hover bounds buffer)
@@ -680,16 +686,11 @@ BUFFER is the buffer where the request has been made."
            (eq buffer (current-buffer)))
       (progn
         (setq lsp-ui-doc--bounds bounds)
-        (and lsp-ui-doc--timer (cancel-timer lsp-ui-doc--timer))
-        (setq lsp-ui-doc--timer
-              (run-with-idle-timer
-               lsp-ui-doc-delay nil
-               (lambda nil
-                 (lsp-ui-doc--display
-                  (thing-at-point 'symbol t)
-                  (-some->> (gethash "contents" hover)
-                    lsp-ui-doc--extract
-                    (replace-regexp-in-string "\r" "")))))))
+        (lsp-ui-doc--display
+         (thing-at-point 'symbol t)
+         (-some->> (gethash "contents" hover)
+           lsp-ui-doc--extract
+           (replace-regexp-in-string "\r" ""))))
     (lsp-ui-doc--hide-frame)))
 
 (defun lsp-ui-doc--delete-frame ()


### PR DESCRIPTION
Since making and sending requests is a nontrivial operation, running it via `post-command-hook` can cause significant slowdowns when typing. Since `lsp-ui-doc` frames are already delayed, I've reordered things such that the request is created and sent after the idle delay instead of before it. 

If many commands are called in a short period, most of the idle timers will be cancelled. Previously, lots of requests would have been made, but their docs would ultimately be ignored. Now those requests won't be made in the first place.

I'm not sure if this is related to #322, but I was personally experiencing a lot of lag while typing with the `texlab` server, with this change, the lag is significantly reduced.



