### PR TITLE
Add clang-tidy specific error explainer for the lsp-ui checker

### DIFF
--- a/lsp-ui-flycheck-clang-tidy.el
+++ b/lsp-ui-flycheck-clang-tidy.el
@@ -1,0 +1,120 @@
+;;; lsp-ui-flycheck-clang-tidy.el --- clang-tidy specific Flycheck support for lsp-mode -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2020 Daniel Martín
+;; URL: https://github.com/emacs-lsp/lsp-ui
+;; Keywords: lsp, ui
+
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; This file contains specific Flycheck functionality for the Clangd
+;; language server.
+;;
+;; If you invoke `flycheck-display-error-explanation' on a
+;; `clang-tidy' error (if the C++ language server is configured to
+;; show `clang-tidy' diagnostics), Emacs will open a detailed
+;; explanation about the message by querying the LLVM website. As an
+;; embedded web browser is used to show the documentation, this
+;; feature requires that Emacs is compiled with libxml2 support.
+
+;;; Code:
+
+(require 'dom)
+
+(defun lsp-ui-flycheck-clang-tidy--skip-http-headers ()
+  "Position point just after HTTP headers."
+  (re-search-forward "^$"))
+
+(defun lsp-ui-flycheck-clang-tidy--narrow-to-http-body ()
+  "Narrow the current buffer to contain the body of an HTTP response."
+  (lsp-ui-flycheck-clang-tidy--skip-http-headers)
+  (narrow-to-region (point) (point-max)))
+
+(defun lsp-ui-flycheck-clang-tidy--decode-region-as-utf8 (start end)
+  "Decode a region from START to END in UTF-8."
+  (condition-case nil
+      (decode-coding-region start end 'utf-8)
+    (coding-system-error nil)))
+
+(defun lsp-ui-flycheck-clang-tidy--remove-crlf ()
+  "Remove carriage return and line feeds from the current buffer."
+  (save-excursion
+    (while (re-search-forward "\r$" nil t)
+      (replace-match "" t t))))
+
+(defun lsp-ui-flycheck-clang-tidy--extract-relevant-doc-section ()
+  "Extract the parts of the LLVM clang-tidy documentation that are relevant.
+
+This function assumes that the current buffer contains the result
+of browsing 'clang.llvm.org', as returned by `url-retrieve'.
+More concretely, this function returns the main <div> element
+with class 'section', and also removes 'headerlinks'."
+  (goto-char (point-min))
+  (lsp-ui-flycheck-clang-tidy--narrow-to-http-body)
+  (lsp-ui-flycheck-clang-tidy--decode-region-as-utf8 (point-min) (point-max))
+  (lsp-ui-flycheck-clang-tidy--remove-crlf)
+  (let* ((dom (libxml-parse-html-region (point-min) (point-max)))
+         (section (dom-by-class dom "section")))
+    (dolist (headerlink (dom-by-class section "headerlink"))
+      (dom-remove-node section headerlink))
+    section))
+
+(defun lsp-ui-flycheck-clang-tidy--explain-error (explanation &rest args)
+  "Explain an error in the Flycheck error explanation buffer using EXPLANATION.
+
+EXPLANATION is a function with optional ARGS that, when
+evaluated, inserts the content in the appropriate Flycheck
+buffer."
+  (with-current-buffer flycheck-explain-error-buffer
+    (let ((inhibit-read-only t)
+          (inhibit-modification-hooks t))
+      (erase-buffer)
+      (apply explanation args)
+      (goto-char (point-min)))))
+
+(defun lsp-ui-flycheck-clang-tidy--show-documentation (error-id)
+  "Show clang-tidy documentation about ERROR-ID.
+
+Information comes from the clang.llvm.org website."
+  (url-retrieve (format
+                 "https://clang.llvm.org/extra/clang-tidy/checks/%s.html" error-id)
+                (lambda (status)
+                  (if-let ((error-status (plist-get status :error)))
+                      (lsp-ui-flycheck-clang-tidy--explain-error
+                       #'insert
+                       (format
+                        "Error accessing clang-tidy documentation: %s"
+                        (error-message-string error-status)))
+                    (let ((doc-contents
+                           (lsp-ui-flycheck-clang-tidy--extract-relevant-doc-section)))
+                      (lsp-ui-flycheck-clang-tidy--explain-error
+                       #'shr-insert-document doc-contents)))))
+  "Loading documentation...")
+
+(defun lsp-ui-flycheck-clang-tidy-error-explainer (error)
+  "Explain a clang-tidy ERROR by scraping documentation from llvm.org."
+  (unless (fboundp 'libxml-parse-html-region)
+    (error "This function requires Emacs to be compiled with libxml2"))
+  (if-let (clang-tidy-error-id (flycheck-error-id error))
+      (condition-case err
+          (lsp-ui-flycheck-clang-tidy--show-documentation clang-tidy-error-id)
+        (error
+         (format
+          "Error accessing clang-tidy documentation: %s"
+          (error-message-string err))))
+    (error "The clang-tidy error message does not contain an [error-id]")))
+
+(provide 'lsp-ui-flycheck-clang-tidy)
+;;; lsp-ui-flycheck-clang-tidy.el ends here

--- a/lsp-ui-flycheck-clang-tidy.el
+++ b/lsp-ui-flycheck-clang-tidy.el
@@ -103,6 +103,7 @@ Information comes from the clang.llvm.org website."
                        #'shr-insert-document doc-contents)))))
   "Loading documentation...")
 
+;;;###autoload
 (defun lsp-ui-flycheck-clang-tidy-error-explainer (error)
   "Explain a clang-tidy ERROR by scraping documentation from llvm.org."
   (unless (fboundp 'libxml-parse-html-region)

--- a/lsp-ui-flycheck.el
+++ b/lsp-ui-flycheck.el
@@ -27,6 +27,7 @@
 ;;; Code:
 
 (require 'lsp-mode)
+(require 'lsp-ui-flycheck-clang-tidy)       ; Specific logic for `clang-tidy' errors
 (require 'flycheck)
 (require 'pcase)
 (require 'dash)
@@ -208,7 +209,10 @@ See https://github.com/emacs-lsp/lsp-mode."
   :start #'lsp-ui-flycheck--start
   :modes '(python-mode) ; Need a default mode
   :predicate (lambda () lsp-mode)
-  :error-explainer (lambda (e) (flycheck-error-message e)))
+  :error-explainer (lambda (e)
+                     (cond ((string-prefix-p "clang-tidy" (flycheck-error-message e))
+                            (lsp-ui-flycheck-clang-tidy-error-explainer e))
+                           (t (flycheck-error-message e)))))
 
 (defun lsp-ui-flycheck-add-mode (mode)
   "Add MODE as a valid major mode for the lsp checker."

--- a/lsp-ui-flycheck.el
+++ b/lsp-ui-flycheck.el
@@ -27,7 +27,6 @@
 ;;; Code:
 
 (require 'lsp-mode)
-(require 'lsp-ui-flycheck-clang-tidy)       ; Specific logic for `clang-tidy' errors
 (require 'flycheck)
 (require 'pcase)
 (require 'dash)


### PR DESCRIPTION
New feature for C++ language servers that emit `clang-tidy` messages (like Clangd).

Press `e` on a `clang-tidy` error and you'll see an explanation from the LLVM website, so that you can learn about the error message before applying a fix-it (if available).

**Screenshot:**

<img width="1544" alt="Screen Shot 2020-02-05 at 10 35 46 PM" src="https://user-images.githubusercontent.com/1573717/73886438-e80aa880-4869-11ea-857f-2416f5018c86.png">
