### PR TITLE
Fix double-spacing in multiline diagnostics

### DIFF
--- a/lsp-ui-sideline.el
+++ b/lsp-ui-sideline.el
@@ -188,7 +188,7 @@ if OFFSET is non-nil, it starts search OFFSET lines from user point line."
         (lsp-ui-sideline--find-line str-len bol eol nil offset)
       (and pos (or (> pos eol) (< pos bol))
            (push pos lsp-ui-sideline--occupied-lines)
-           (list pos index)))))
+           (list pos (1- index))))))
 
 (defun lsp-ui-sideline--delete-ov ()
   "Delete overlays."


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/6559064/74079103-883a0c00-49e7-11ea-9484-f499f207d51f.png)

After:

![image](https://user-images.githubusercontent.com/6559064/74079105-912add80-49e7-11ea-9a93-7f8e77f033e9.png)

I don't really understand why the code was the way it was to begin with, so it's entirely possible that this change is wrong and breaks some other use case. I would welcome suggestions.