### PR TITLE
Fix current buffer in callback

### DIFF
--- a/lsp-ui-doc.el
+++ b/lsp-ui-doc.el
@@ -677,11 +677,11 @@ HEIGHT is the documentation number of lines."
                  lsp-ui-doc-delay nil
                  (let ((buf (current-buffer)))
                    (lambda nil
-                     (with-current-buffer buf
+                     (when (equal buf (current-buffer))
                        (lsp--send-request-async
                         (lsp--make-request "textDocument/hover" (lsp--text-document-position-params))
                         (lambda (hover)
-                          (with-current-buffer buf
+                          (when (equal buf (current-buffer))
                             (lsp-ui-doc--callback hover bounds (current-buffer)))))))))))
       (lsp-ui-doc--hide-frame))))
 

--- a/lsp-ui-doc.el
+++ b/lsp-ui-doc.el
@@ -675,10 +675,14 @@ HEIGHT is the documentation number of lines."
           (setq lsp-ui-doc--timer
                 (run-with-idle-timer
                  lsp-ui-doc-delay nil
-                 (lambda nil
-                   (lsp--send-request-async
-                    (lsp--make-request "textDocument/hover" (lsp--text-document-position-params))
-                    (lambda (hover) (lsp-ui-doc--callback hover bounds (current-buffer))))))))
+                 (let ((buf (current-buffer)))
+                   (lambda nil
+                     (with-current-buffer buf
+                       (lsp--send-request-async
+                        (lsp--make-request "textDocument/hover" (lsp--text-document-position-params))
+                        (lambda (hover)
+                          (with-current-buffer buf
+                            (lsp-ui-doc--callback hover bounds (current-buffer)))))))))))
       (lsp-ui-doc--hide-frame))))
 
 (defun lsp-ui-doc--callback (hover bounds buffer)


### PR DESCRIPTION
Otherwise if the user changes which buffer is current before the callback is triggered, the callback will act on the wrong buffer, which may cause an error if for example the new buffer does not have a backing file.