### PR TITLE
add test for lsp-ui-flycheck-list--update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,55 @@
+language: emacs-lisp
+dist: trusty
+sudo: required
+
+notifications:
+  email: false
+
+cache:
+  - directories:
+      - $HOME/emacs
+      - $HOME/.cache/pip
+      - $HOME/.emacs.d
+      - $HOME/.cargo
+      - $TRAVIS_BUILD_DIR/.cask
+
+matrix:
+  allow_failures:
+    - env: EMACS_VERSION=snapshot
+  fast_finish: true
+  include:
+    - env: EMACS_VERSION=26.1
+    - env: EMACS_VERSION=snapshot
+
+before_install:
+  # Configure $PATH: Executables are installed to $HOME/bin
+  - export PATH="$HOME/bin:$PATH"
+  # Download the makefile to emacs-travis.mk
+  - wget 'https://raw.githubusercontent.com/flycheck/emacs-travis/master/emacs-travis.mk'
+  # Install Emacs (according to $EMACS_VERSION) and Cask
+  - make -f emacs-travis.mk install_gnutls install_emacs
+  - make -f emacs-travis.mk install_cask
+
+  - sudo apt update
+  - sudo apt install -y gnutls-bin gnupg2 dirmngr
+
+  - sudo apt install -y texinfo libgif-dev libxpm-dev
+  - curl -sSf https://build.travis-ci.com/files/rustup-init.sh | sh -s -- --default-toolchain=stable -y
+  - source $HOME/.cargo/env
+
+  # install RLS
+  - rustup component add rls rust-analysis rust-src
+  # install rust-analyzer
+  - git clone https://github.com/rust-analyzer/rust-analyzer && cd rust-analyzer
+  - cargo xtask install --server && cd ..
+
+install:
+  - mkdir -p $HOME/.emacs.d/elpa/gnupg || true
+  - chmod 700 $HOME/.emacs.d/elpa/gnupg
+  - gpg2 --keyserver hkp://pool.sks-keyservers.net:80 --homedir $HOME/.emacs.d/elpa/gnupg --recv-keys 066DAFCB81E42C40 || true
+  - mkdir -p $(cask package-directory) || true
+  - rsync -azSH $HOME/.emacs.d/elpa/gnupg $(cask package-directory)
+  - cask install
+
+script:
+  - cask exec ert-runner

--- a/Cask
+++ b/Cask
@@ -1,10 +1,12 @@
 (source gnu)
 (source melpa)
 
+(depends-on "ert-runner")
 (depends-on "dash")
 (depends-on "flycheck")
 (depends-on "lsp-mode")
 (depends-on "markdown-mode")
+(depends-on "rustic")
 
 (package-file "lsp-ui.el")
 (files "*.el" "lsp-ui-doc.html")

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,12 @@
+EMACS ?= emacs
 SHELL := /bin/bash
 
 all:
-	cask build
+	EMACS=$(EMACS) cask install
+	EMACS=$(EMACS) cask build
+	EMACS=$(EMACS) cask clean-elc
 
-.PHONY: all
+test: all
+	EMACS=$(EMACS) cask exec ert-runner
+
+.PHONY: all test

--- a/lsp-ui-flycheck.el
+++ b/lsp-ui-flycheck.el
@@ -65,6 +65,8 @@ If nil, diagnostics will be reported according to `flycheck-check-syntax-automat
     (forward-line -1)))
 
 (defun lsp-ui-flycheck-list--update (window workspace)
+  "Update flycheck buffer in WINDOW belonging to WORKSPACE.
+Use `lsp-diagnostics' to receive diagnostics from your LSP server."
   (let ((buffer-read-only nil)
         (lsp--cur-workspace workspace))
     (erase-buffer)

--- a/test/lsp-ui-flycheck-test.el
+++ b/test/lsp-ui-flycheck-test.el
@@ -1,0 +1,22 @@
+;; -*- lexical-binding: t -*-
+
+(ert-deftest lsp-ui-test-flycheck-list--update ()
+  "Test if `lsp-ui-flycheck-list--update' populates buffer *lsp-diagnostics*."
+  (let ((rustic-lsp-setup-p t)
+        (rustic-lsp-server 'rust-analyzer))
+    (setq lsp-log-io t)
+    (let* ((buffer (get-buffer-create "*lsp-diagnostics*"))
+           (string "fn main() {\nlet bar = 1;\nbar = bar + 2;}")
+           (dir (lsp-ui-test-create-project-buffer buffer string))
+           (file (concat dir "src/main.rs"))
+           (buf (get-file-buffer file))
+           (diagnostics "2: rustc: value assigned to `bar` is never read
+2: rustc: cannot assign twice to immutable variable `bar`
+"))
+      (sit-for 3)
+      (with-current-buffer buffer
+        (lsp-ui-flycheck-list--update (selected-window) (lsp-find-workspace 'rust-analyzer default-directory))
+        (should (string= (buffer-substring-no-properties (point-min) (point-max)) diagnostics))
+        (with-lsp-workspace (lsp-find-workspace 'rust-analyzer default-directory)
+          (lsp--shutdown-workspace))))))
+

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -1,0 +1,38 @@
+;;; -*- lexical-binding: t; -*-
+
+
+(add-to-list 'load-path
+             (file-name-as-directory (f-parent (f-parent (f-this-file)))))
+
+(require 'lsp-mode)
+(require 'lsp-rust)
+(require 'lsp-ui)
+(require 'flycheck)
+(require 'lsp-ui-flycheck)
+(require 'rustic)
+
+;; don't start LSP server for every test
+(setq rustic-lsp-setup-p nil)
+
+(setq lsp-restart 'ignore)
+
+(defun lsp-ui-test-generate-project ()
+  (let* ((default-directory "/tmp")
+         (dir (make-temp-file-internal "cargo" 0 "" nil)))
+    (shell-command-to-string (format "cargo new %s --bin --quiet" dir))
+        (concat (expand-file-name dir) "/")))
+
+(defun lsp-ui-test-create-project-buffer (buffer string)
+  "Populate BUFFER with STRING."
+  (let* ((dir (lsp-ui-test-generate-project))
+         (src (concat dir "/src"))
+         (file (expand-file-name "main.rs" src))
+         (rustic-format-trigger nil))
+    (with-current-buffer buffer
+      (write-file file)
+      (insert string)
+      (save-buffer))
+    dir))
+
+
+;;; test-helper.el ends here


### PR DESCRIPTION
I started with this function, because it's an easy start. @yyoncho you moved some stuff to lsp-mode recently, is `lsp-ui-flycheck-list--update` actually still relevant ?

I also included rustic in the tests because I already added a test with a running lsp server to it. I guess I will switch to rust-mode since it has less dependencies. But this way I could copy and paste almost everything.