### PR TITLE
Add cancel tokens for lsp-ui requests

### DIFF
--- a/lsp-ui-doc.el
+++ b/lsp-ui-doc.el
@@ -679,11 +679,14 @@ HEIGHT is the documentation number of lines."
                  (let ((buf (current-buffer)))
                    (lambda nil
                      (when (equal buf (current-buffer))
-                       (lsp--send-request-async
-                        (lsp--make-request "textDocument/hover" (lsp--text-document-position-params))
+                       (lsp-request-async
+                        "textDocument/hover"
+                        (lsp--text-document-position-params)
                         (lambda (hover)
                           (when (equal buf (current-buffer))
-                            (lsp-ui-doc--callback hover bounds (current-buffer)))))))))))
+                            (lsp-ui-doc--callback hover bounds (current-buffer))))
+                        :mode 'tick
+                        :cancel-token :lsp-ui-doc-hover)))))))
       (lsp-ui-doc--hide-frame))))
 
 (defun lsp-ui-doc--callback (hover bounds buffer)

--- a/lsp-ui-sideline.el
+++ b/lsp-ui-sideline.el
@@ -449,7 +449,8 @@ from the language server."
                      :context (list :diagnostics (lsp-cur-line-diagnostics)))
              (lsp--text-document-code-action-params))
            (lambda (actions) (lsp-ui-sideline--code-actions actions bol eol))
-           :mode 'alive))
+           :mode 'alive
+           :cancel-token :lsp-ui-code-actions))
         ;; Go through all symbols and request hover information.  Note that the symbols are
         ;; traversed backwards as `forward-symbol' with a positive argument will jump just past the
         ;; current symbol.  By going from the end of the line towards the front, point will be placed

--- a/lsp-ui.el
+++ b/lsp-ui.el
@@ -120,9 +120,8 @@ Both should have the form (FILENAME LINE COLUMN)."
 
 (defun lsp-ui--reference-triples (extra)
   "Return references as a list of (FILENAME LINE COLUMN) triples."
-  (let ((refs (lsp--send-request (lsp--make-request
-                                  "textDocument/references"
-                                  (append (lsp--text-document-position-params) extra)))))
+  (let ((refs (lsp-request "textDocument/references"
+                           (append (lsp--text-document-position-params) extra))))
     (sort
      (mapcar
       (lambda (ref)


### PR DESCRIPTION
- the fact that we are not sending cancel tokens is causing troubles to some of
the language servers(e. g. clangd).