### PR TITLE
[lsp-ui-sideline] Set maximum height for text in sideline

### DIFF
--- a/lsp-ui-sideline.el
+++ b/lsp-ui-sideline.el
@@ -258,7 +258,7 @@ CURRENT is non-nil when the point is on the symbol."
     (add-face-text-property 0 len 'lsp-ui-sideline-global nil str)
     (concat
      (propertize " " 'display `(space :align-to (- right-fringe ,(lsp-ui-sideline--align len margin))))
-     str)))
+     (propertize str 'display '(height 1)))))
 
 (defun lsp-ui-sideline--check-duplicate (symbol info)
   "Check if there's already a SYMBOL containing INFO, unless `lsp-ui-sideline-ignore-duplicate'
@@ -367,7 +367,7 @@ Push sideline overlays on `lsp-ui-sideline--ovs'."
                                  (add-face-text-property 0 len face nil message)
                                  message))
                  (string (concat (propertize " " 'display `(space :align-to (- right-fringe ,(lsp-ui-sideline--align len margin))))
-                                 message))
+                                 (propertize message 'display '(height 1))))
                  (pos-ov (lsp-ui-sideline--find-line len bol eol nil offset))
                  (ov (and pos-ov (make-overlay (car pos-ov) (car pos-ov)))))
             (when pos-ov
@@ -412,7 +412,7 @@ Push sideline overlays on `lsp-ui-sideline--ovs'."
                           (add-text-properties 0 len `(keymap ,keymap mouse-face highlight) title)
                           title))
             (string (concat (propertize " " 'display `(space :align-to (- right-fringe ,(lsp-ui-sideline--align len margin))))
-                            title))
+                            (propertize title 'display '(height 1))))
             (pos-ov (lsp-ui-sideline--find-line (1+ (length title)) bol eol t))
             (ov (and pos-ov (make-overlay (car pos-ov) (car pos-ov)))))
       (when pos-ov


### PR DESCRIPTION
markdown-mode sometime renders text with bigger size, which break
sideline's rendering:

![sideline](https://user-images.githubusercontent.com/5273820/87849238-8f136600-c919-11ea-92f7-e78fc1b58f65.png)

Rendering with this PR:
![sideline2](https://user-images.githubusercontent.com/5273820/87849242-98043780-c919-11ea-98d8-0a6017cae849.png)
