### PR TITLE
fix issue in find-prev(next)-reference (regression of d92cf83)

### DIFF
--- a/lsp-ui.el
+++ b/lsp-ui.el
@@ -135,7 +135,7 @@ Both should have the form (FILENAME LINE COLUMN)."
 (defun lsp-ui-find-next-reference (&optional extra)
   "Find next reference of the symbol at point."
   (interactive)
-  (let* ((cur (list buffer-file-name (line-number-at-pos) (- (point) (line-beginning-position))))
+  (let* ((cur (list buffer-file-name (- (line-number-at-pos) 1) (- (point) (line-beginning-position))))
          (refs (lsp-ui--reference-triples extra))
          (idx -1)
          (res (-first (lambda (ref) (cl-incf idx) (lsp-ui--location< cur ref)) refs)))
@@ -152,7 +152,7 @@ Both should have the form (FILENAME LINE COLUMN)."
 (defun lsp-ui-find-prev-reference (&optional extra)
   "Find previous reference of the symbol at point."
   (interactive)
-  (let* ((cur (list buffer-file-name (line-number-at-pos) (- (point) (line-beginning-position))))
+  (let* ((cur (list buffer-file-name (- (line-number-at-pos) 1) (- (point) (line-beginning-position))))
          (refs (lsp-ui--reference-triples extra))
          (idx -1)
          (res (-last (lambda (ref) (and (lsp-ui--location< ref cur) (cl-incf idx))) refs)))


### PR DESCRIPTION
This is a fix for the regression of this change (https://github.com/emacs-lsp/lsp-ui/commit/d92cf83d95c9ca177b735500ead88cf68dc2e2db)
zero-based line number should be used, the LSP textDocument/references returns zero-based line numbers per the LSP spec.
the result of  `line-number-at-pos` is one-based, while the previous used `lsp--cur-line` is zero-based.