### PR TITLE
Add support for Strings as MarkedStrings

### DIFF
--- a/lsp-ui-doc.el
+++ b/lsp-ui-doc.el
@@ -300,6 +300,10 @@ We don't extract the string that `lps-line' is already displaying."
          (lsp:marked-string-language contents))
     (lsp-ui-doc--extract-marked-string (lsp:marked-string-value contents)
                                        (lsp:marked-string-language contents)))
+   ;; The specification for MarkedString also includes raw strings of
+   ;; markdown, which is not reflected by `lsp-marked-string?'
+   ((stringp contents)
+    (lsp-ui-doc--extract-marked-string contents lsp/markup-kind-markdown))
    ((lsp-marked-string? contents) (lsp-ui-doc--extract-marked-string contents))
    ((and (lsp-markup-content? contents)
          (string= (lsp:markup-content-kind contents) lsp/markup-kind-markdown))


### PR DESCRIPTION
Much of the context for this change can be found here: #478 

To recap: [The LSP spec for `MarkedString`](https://microsoft.github.io/language-server-protocol/specification#textDocument_hover) is a union type of `string` and an object of the form `{ language: string; value: string }`. [The definition of the `MarkedString` type in `lsp-protocol.el`](https://github.com/emacs-lsp/lsp-mode/blob/master/lsp-protocol.el#L470) only supports the object and not `string`. Presently, `lsp-mode` has no support for union types.

In order to support this feature of the LSP spec, I added a check to see if the content received was a `string`, and if so treat it as a valid `MarkedString` containing markdown. This should be the correct behaviour as the LSP spec states:

```
 * MarkedString can be used to render human readable text. It is either a markdown string
 * or a code-block that provides a language and a code snippet.
```

This change also fixes the precise concern (elixir-ls not displaying documentation pop-ups) of #478.

![image](https://user-images.githubusercontent.com/2058614/89928608-129d3b80-dbd6-11ea-9595-69376cd5853b.png)
