### PR TITLE
[lsp-ui-sideline] Don't re-render hovers/diagnostics on same line

### DIFF
--- a/lsp-ui-sideline.el
+++ b/lsp-ui-sideline.el
@@ -544,7 +544,7 @@ from the language server."
          (lambda (actions) (lsp-ui-sideline--code-actions actions bol eol))
          :mode 'tick
          :error-handler
-         (lambda (&rest)
+         (lambda (&rest _)
            (lsp-ui-sideline--delete-kind 'actions))
          :cancel-token :lsp-ui-code-actions))
       ;; Go through all symbols and request hover information.  Note that the symbols are

--- a/lsp-ui-sideline.el
+++ b/lsp-ui-sideline.el
@@ -565,19 +565,21 @@ from the language server."
               ;; Skip strings and comments
               (when (and symbol (not in-string) outside-comment)
                 (push (list symbol bounds (list :line (1- line-widen) :character (- (point) bol))) symbols))))
-          (let ((last-symbol (1- (length symbols)))
-                list-infos)
-            (--each-indexed symbols
-              (-let (((symbol bounds position) it)
-                     (index it-index))
-                (lsp-request-async
-                 "textDocument/hover"
-                 (lsp-make-hover-params :text-document doc-id :position position)
-                 (lambda (info)
-                   (and info (push (list symbol bounds info) list-infos))
-                   (when (= index last-symbol)
-                     (lsp-ui-sideline--display-all-info list-infos tag bol eol)))
-                 :mode 'tick)))))))))
+          (if (null symbols)
+              (lsp-ui-sideline--delete-kind 'info)
+            (let ((last-symbol (1- (length symbols)))
+                  list-infos)
+              (--each-indexed symbols
+                (-let (((symbol bounds position) it)
+                       (index it-index))
+                  (lsp-request-async
+                   "textDocument/hover"
+                   (lsp-make-hover-params :text-document doc-id :position position)
+                   (lambda (info)
+                     (and info (push (list symbol bounds info) list-infos))
+                     (when (= index last-symbol)
+                       (lsp-ui-sideline--display-all-info list-infos tag bol eol)))
+                   :mode 'tick))))))))))
 
 (defun lsp-ui-sideline--stop-p ()
   "Return non-nil if the sideline should not be display."


### PR DESCRIPTION
Render hover informations and diagnostics only when changing lines.
Only actions are updated when moving point on the same line

Fixes #434