### PR TITLE
Define key map directly.

### DIFF
--- a/lsp-ui-flycheck.el
+++ b/lsp-ui-flycheck.el
@@ -153,14 +153,13 @@ Use `lsp-diagnostics' to receive diagnostics from your LSP server."
   (interactive)
   (kill-buffer))
 
-(defvar lsp-ui-flycheck-list-mode-map nil
-  "Keymap for ‘lsp-ui-flycheck-list-mode’.")
-(unless lsp-ui-flycheck-list-mode-map
+(defvar lsp-ui-flycheck-list-mode-map
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "q") 'lsp-ui-flycheck-list--quit)
     (define-key map (kbd "<return>") 'lsp-ui-flycheck-list--view)
     (define-key map (kbd "<M-return>") 'lsp-ui-flycheck-list--visit)
-    (setq lsp-ui-flycheck-list-mode-map map)))
+    map)
+  "Keymap for ‘lsp-ui-flycheck-list-mode’.")
 
 (define-derived-mode lsp-ui-flycheck-list-mode special-mode "lsp-ui-flycheck-list"
   "Mode showing flycheck diagnostics for the whole workspace."

--- a/lsp-ui-imenu.el
+++ b/lsp-ui-imenu.el
@@ -323,9 +323,7 @@ Return the updated COLOR-INDEX."
       (recenter)
       (pulse-momentary-highlight-one-line (point) 'next-error))))
 
-(defvar lsp-ui-imenu-mode-map nil
-  "Keymap for ‘lsp-ui-peek-mode’.")
-(unless lsp-ui-imenu-mode-map
+(defvar lsp-ui-imenu-mode-map
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "q") 'lsp-ui-imenu--kill)
     (define-key map (kbd "<right>") 'lsp-ui-imenu--next-kind)
@@ -334,7 +332,8 @@ Return the updated COLOR-INDEX."
     (define-key map (kbd "<M-return>") 'lsp-ui-imenu--visit)
     (define-key map (kbd "RET") 'lsp-ui-imenu--view)
     (define-key map (kbd "M-RET") 'lsp-ui-imenu--visit)
-    (setq lsp-ui-imenu-mode-map map)))
+    map)
+  "Keymap for ‘lsp-ui-peek-mode’.")
 
 (define-derived-mode lsp-ui-imenu-mode special-mode "lsp-ui-imenu"
   "Mode showing imenu entries.")

--- a/lsp-ui-peek.el
+++ b/lsp-ui-peek.el
@@ -528,9 +528,7 @@ XREFS is a list of references/definitions."
   (interactive)
   (lsp-ui-peek--goto-xref nil t))
 
-(defvar lsp-ui-peek-mode-map nil
-  "Keymap for ‘lsp-ui-peek-mode’.")
-(unless lsp-ui-peek-mode-map
+(defvar lsp-ui-peek-mode-map
   (let ((map (make-sparse-keymap)))
     (suppress-keymap map t)
     (define-key map "\e\e\e" 'lsp-ui-peek--abort)
@@ -549,7 +547,8 @@ XREFS is a list of references/definitions."
     (define-key map (kbd "q") 'lsp-ui-peek--abort)
     (define-key map (kbd "RET") 'lsp-ui-peek--goto-xref)
     (define-key map (kbd "M-RET") 'lsp-ui-peek--goto-xref-other-window)
-    (setq lsp-ui-peek-mode-map map)))
+    map)
+  "Keymap for ‘lsp-ui-peek-mode’.")
 
 (defun lsp-ui-peek--disable ()
   "Do not call this function, call `lsp-ui-peek--abort' instead."
@@ -558,6 +557,7 @@ XREFS is a list of references/definitions."
     (lsp-ui-peek--peek-hide)))
 
 (defun lsp-ui-peek--abort ()
+  "Abort peek."
   (interactive)
   ;; The timer fixes https://github.com/emacs-lsp/lsp-ui/issues/33
   (run-with-idle-timer 0 nil 'lsp-ui-peek--disable))


### PR DESCRIPTION
Is there a reason that we don't declare key map variable directly? 😕 

Thanks!