### PR TITLE
Some logic clean up and better with defense programming.

### DIFF
--- a/lsp-ui-sideline.el
+++ b/lsp-ui-sideline.el
@@ -636,8 +636,7 @@ COMMAND is `company-pseudo-tooltip-frontend' parameter."
 This does not toggle display of flycheck diagnostics or code actions."
   (interactive)
   (when (bound-and-true-p lsp-ui-sideline-mode)
-    (setq lsp-ui-sideline-show-hover
-          (not lsp-ui-sideline-show-hover))
+    (setq lsp-ui-sideline-show-hover (not lsp-ui-sideline-show-hover))
     (lsp-ui-sideline--run)))
 
 (defun lsp-ui-sideline--diagnostics-changed ()
@@ -649,8 +648,7 @@ This does not toggle display of flycheck diagnostics or code actions."
 (defun lsp-ui-sideline--erase (&rest _)
   "Remove all sideline overlays and delete last tag."
   (when (bound-and-true-p lsp-ui-sideline-mode)
-    (ignore-errors
-      (lsp-ui-sideline--delete-ov))))
+    (ignore-errors (lsp-ui-sideline--delete-ov))))
 
 (define-minor-mode lsp-ui-sideline-mode
   "Minor mode for showing information for current line."

--- a/lsp-ui-sideline.el
+++ b/lsp-ui-sideline.el
@@ -579,13 +579,13 @@ from the language server."
                    "textDocument/hover"
                    (lsp-make-hover-params :text-document doc-id :position position)
                    (lambda (info)
-                     (setq current-index (1+ current-index))
+                     (cl-incf current-index)
                      (and info (push (list symbol bounds info) list-infos))
                      (when (= current-index length-symbols)
                        (lsp-ui-sideline--display-all-info list-infos tag bol eol)))
                    :error-handler
                    (lambda (&rest _)
-                     (setq current-index (1+ current-index))
+                     (cl-incf current-index)
                      (when (= current-index length-symbols)
                        (lsp-ui-sideline--display-all-info list-infos tag bol eol)))
                    :mode 'tick))))))))))


### PR DESCRIPTION
This patch does the following changes.

#### For imenu

* Some logic clean up
* Use defense programming strategy to `lsp-ui-imenu--get-padding`.
* Supply missing docstring. (By my understanding)

#### For sideline

* Some operations changed.
* Removed unnecessary newlines that may cause confusions.