### PR TITLE
Don't use interactive kill-* commands in doc cleanup

### DIFF
--- a/lsp-ui-doc.el
+++ b/lsp-ui-doc.el
@@ -632,9 +632,6 @@ FN is the function to call on click."
               before (char-before))
         (delete-region (point) (save-excursion
                                  (forward-visible-line 1)
-                                 (if (eobp)
-                                     (signal 'end-of-buffer nil))
-                                 (end-of-visible-line)
                                  (point)))
         (setq after (char-after (1+ (point))))
         (insert

--- a/lsp-ui-doc.el
+++ b/lsp-ui-doc.el
@@ -601,7 +601,8 @@ FN is the function to call on click."
   (insert (propertize "\n" 'face '(:height 0.2)))
   (while (not (eobp))
     (when (and (eolp) (not (bobp)))
-      (kill-whole-line)
+      (save-excursion
+        (delete-region (point) (progn (forward-visible-line 1) (point))))
       (when (or (and (not (get-text-property (point) 'markdown-heading))
                      (not (get-text-property (max (- (point) 2) 1) 'markdown-heading)))
                 (get-text-property (point) 'markdown-hr))
@@ -629,7 +630,12 @@ FN is the function to call on click."
         (goto-char next)
         (setq bolp (bolp)
               before (char-before))
-        (kill-line 1)
+        (delete-region (point) (save-excursion
+                                 (forward-visible-line 1)
+                                 (if (eobp)
+                                     (signal 'end-of-buffer nil))
+                                 (end-of-visible-line)
+                                 (point)))
         (setq after (char-after (1+ (point))))
         (insert
          (concat

--- a/test/lsp-ui-doc-test.el
+++ b/test/lsp-ui-doc-test.el
@@ -1,0 +1,57 @@
+;; -*- lexical-binding: t -*-
+
+
+(require 'lsp-ui-doc)
+
+(ert-deftest lsp-ui-doc--make-smaller-empty-lines ()
+  "Test if `lsp-ui-doc--make-smaller-empty-lines' correctly replaces lines"
+  (let ((string "This is a test
+
+It will show it will shrink empty lines
+"))
+    (with-temp-buffer
+      (insert string)
+      (lsp-ui-doc--make-smaller-empty-lines)
+      (should (ert-equal-including-properties
+               #("
+This is a test
+ 
+It will show it will shrink empty lines
+
+
+"
+                 0 1 (lsp-ui-doc-no-space t face (:height 0.2))
+                 16 17 (lsp-ui-doc-no-space t face (:height 0.5))
+                 17 18 (face (:height 0.5))
+                 58 60 (lsp-ui-doc-no-space t face (:height 0.3)))
+               (buffer-substring (point-min) (point-max)))))))
+
+
+(ert-deftest lsp-ui-doc--handle-hr-lines ()
+  "Test if `lsp-ui-doc--handle-hr-lines' correctly replaces markdown hrules"
+  (let ((string "Before
+
+---
+Text
+
+---
+After"))
+    (with-temp-buffer
+      (insert string)
+      (markdown-mode)
+      (lsp-ui-doc--handle-hr-lines)
+      (should (ert-equal-including-properties
+               #("Before
+
+   
+Text
+
+   
+After"
+                 8 9 (display (space :height (1)) lsp-ui-doc--replace-hr t face (:background "dark grey"))
+                 9 10 (display (space :height (1)))
+                 10 12 (face (:height 0.2))
+                 18 19 (display (space :height (1)) lsp-ui-doc--replace-hr t face (:background "dark grey"))
+                 19 20 (display (space :height (1)))
+                 20 22 (face (:height 0.2)))
+               (buffer-substring (point-min) (point-max)))))))


### PR DESCRIPTION
While trying to copy a symbol from a buffer text was inconveniently
pre-pended and in some cases appended depending on if the lsp-ui doc
cleanup happens before or after killing interactively in my buffer.

Some examples of entries from the `kill-ring` variable

e.g. Me trying to copy some text
```
"

---
git2::Error"
```

e.g. an example of a weird entry found in my kill ring, there are many
more like this, some a just huge strings of empty lines.
```
"

---
"
```

This is happening because the interactive kill-* commands all put data
onto the kill ring.  If the previous command was `kill-region`, then the
next kill command will append to the previous kill ring entry.