### PR TITLE
Fix lsp-ui-peek-find-definition changing origin buffer start window

### DIFF
--- a/lsp-ui-peek.el
+++ b/lsp-ui-peek.el
@@ -477,7 +477,8 @@ XREFS is a list of references/definitions."
     (delete-overlay lsp-ui-peek--overlay))
   (setq lsp-ui-peek--overlay nil
         lsp-ui-peek--last-xref nil)
-  (set-window-start (get-buffer-window) lsp-ui-peek--win-start))
+  (when lsp-ui-peek--win-start
+    (set-window-start (get-buffer-window) lsp-ui-peek--win-start)))
 
 (defun lsp-ui-peek--deactivate-keymap ()
   "Deactivate keymap."


### PR DESCRIPTION
When the same buffer is splitted and I use `lsp-ui-peek-find-definition`, the left window(origin buffer) start is changed incorrectly

Gif:
![lsp-ui-peek-bug](https://user-images.githubusercontent.com/7820865/93671152-f1522980-fa76-11ea-92a6-b2b1d134ec33.gif)
