### PR TITLE
change default value of lsp-ui-doc-position to at-point

### DIFF
--- a/lsp-ui-doc.el
+++ b/lsp-ui-doc.el
@@ -83,7 +83,7 @@
   :type 'boolean
   :group 'lsp-ui-doc)
 
-(defcustom lsp-ui-doc-position 'top
+(defcustom lsp-ui-doc-position 'at-point
   "Where to display the doc when moving the point cursor.
 This affect the position of the documentation when `lsp-ui-doc-show-with-cursor'
 is non-nil."


### PR DESCRIPTION
I think most users prefer this position. But maybe I'm wrong...