### PR TITLE
Revert "change default value of lsp-ui-doc-position to at-point (#518)"

### DIFF
--- a/lsp-ui-doc.el
+++ b/lsp-ui-doc.el
@@ -83,7 +83,7 @@
   :type 'boolean
   :group 'lsp-ui-doc)
 
-(defcustom lsp-ui-doc-position 'at-point
+(defcustom lsp-ui-doc-position 'top
   "Where to display the doc when moving the point cursor.
 This affect the position of the documentation when `lsp-ui-doc-show-with-cursor'
 is non-nil."


### PR DESCRIPTION
The error of #519 seems to be related to the doc position. I would revert this for now.