### PR TITLE
Remove incorrect documentation from lsp-ui-flycheck.el

### DIFF
--- a/lsp-ui-flycheck.el
+++ b/lsp-ui-flycheck.el
@@ -20,10 +20,7 @@
 
 ;;; Commentary:
 
-;; Flycheck integration for lsp-mode.  To enable, put this in your config:
-;; (require 'lsp-ui-flycheck)
-;; (with-eval-after-load 'lsp-mode
-;;   (add-hook 'lsp-after-open-hook (lambda () (lsp-ui-flycheck-enable 1))))
+;; Flycheck integration for lsp-mode.
 
 ;;; Code:
 


### PR DESCRIPTION
The opening documentation says `lsp-ui-flycheck-enable` should be called to enable lsp-ui-flycheck, but that function was removed.