### PR TITLE
Update a couple faces to look good on light background's

### DIFF
--- a/lsp-ui-peek.el
+++ b/lsp-ui-peek.el
@@ -109,13 +109,12 @@ By default, the peek view isn't shown if there is 1 xref."
   :group 'lsp-ui-peek)
 
 (defface lsp-ui-peek-highlight
-  '((((background light)) :background "dim gray"
-     :foreground "white"
-     :distant-foreground "black")
+  '((((background light)) :background "yellow"
+     :box (:line-width -1 :color "red"))
     (t :background "white"
        :foreground "black"
        :distant-foreground "white"
-       :box (:line-width -1 :color "white")))
+       :box (:line-width -1 :color "red")))
   "Face used to highlight the reference/definition.
 Do not use box, underline or overline prop.  If you want to use
 box, use a negative value for its width.  Those properties deform

--- a/lsp-ui-sideline.el
+++ b/lsp-ui-sideline.el
@@ -152,20 +152,21 @@ It is used to know when the window has changed of width.")
   :group 'lsp-ui-sideline)
 
 (defface lsp-ui-sideline-current-symbol
-  '((default
-      :foreground "white"
-      :weight ultra-bold
-      :box (:line-width -1 :color "white")
-      :height 0.99)
-    (((background light))
-     :foreground "dim gray"
-     :box (:line-width -1 :color "dim gray")))
+  '((((background light))
+     :foreground "black"
+     :weight ultra-bold
+     :box (:line-width -1 :color "black")
+     :height 0.99)
+    (t :foreground "white"
+       :weight ultra-bold
+       :box (:line-width -1 :color "white")
+       :height 0.99))
   "Face used to highlight the symbol on point."
   :group 'lsp-ui-sideline)
 
 (defface lsp-ui-sideline-code-action
-  '((default :foreground "yellow")
-    (((background light)) :foreground "DarkOrange"))
+  '((((background light)) :foreground "DarkOrange")
+    (t :foreground "yellow"))
   "Face used to highlight code action text."
   :group 'lsp-ui-sideline)
 


### PR DESCRIPTION
- lsp-ui-peek-highlight had handling for light background but dim gray is too light. Also
  can we add a red box as this looks good.

- lsp-ui-sideline-current-symbol had handling for light backgrounds, but order was wrong, also
  dim gray and the light background are too close, thus proposed a more visible colors

- lsp-ui-sideline-code-action had handling for light backgrounds, but order was wrong, fixed.