### PR TITLE
Add 27.1 for CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,7 @@ jobs:
           - 26.1
           - 26.2
           - 26.3
+          - 27.1
           - snapshot
 
     steps:


### PR DESCRIPTION
I think Emacs version `27.1` should also be test with CI?