### PR TITLE
Hide ui-doc when inside minibuffer

### DIFF
--- a/lsp-ui-doc.el
+++ b/lsp-ui-doc.el
@@ -985,20 +985,20 @@ before, or if the new window is the minibuffer."
 This function is apply to hook `window-scroll-functions'.
 
 Argument WIN is current applying window."
-  (let ((frame (lsp-ui-doc--get-frame)))
-    (and frame
-         (eq lsp-ui-doc-position 'at-point)
-         (frame-visible-p frame)
-         (eq win (selected-window))  ; This resolved #524
-         (if (and lsp-ui-doc--bounds
-                  (eq (window-buffer) (frame-parameter frame 'lsp-ui-doc--buffer-origin))
-                  (not (minibufferp (window-buffer)))
-                  (>= (point) (car lsp-ui-doc--bounds))
-                  (<= (point) (cdr lsp-ui-doc--bounds)))
-             (lsp-ui-doc--move-frame frame)
-           ;; The point might have changed if the window was scrolled
-           ;; too far
-           (lsp-ui-doc--hide-frame)))))
+  (let ((frame (lsp-ui-doc--get-frame)) hide-it)
+    (cond ((not (minibufferp (window-buffer)))
+           (setq hide-it t))
+          ((and frame
+                (eq lsp-ui-doc-position 'at-point)
+                (frame-visible-p frame)
+                (eq win (selected-window))  ; This resolved #524
+                lsp-ui-doc--bounds
+                (eq (window-buffer) (frame-parameter frame 'lsp-ui-doc--buffer-origin))
+                (>= (point) (car lsp-ui-doc--bounds))
+                (<= (point) (cdr lsp-ui-doc--bounds)))
+           (lsp-ui-doc--move-frame frame))
+          (t (setq hide-it t)))
+    (when hide-it (lsp-ui-doc--hide-frame))))
 
 (defvar-local lsp-ui-doc--timer-mouse-movement nil)
 (defvar-local lsp-ui-doc--last-event nil)


### PR DESCRIPTION
Prior to hide `ui-doc` when user is executing inside minibuffer. This resolve the flashes while inside minibuffer, see issue #524.