### PR TITLE
README.md: add two important lsp-ui-doc variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ Customization:
 - `lsp-ui-doc-enable` enable lsp-ui-doc
 - `lsp-ui-doc-position` Where to display the doc
 - `lsp-ui-doc-delay` Number of seconds before showing the doc
+- `lsp-ui-doc-show-with-cursor` When non-nil, move the cursor over a symbol to show the doc
+- `lsp-ui-doc-show-with-mouse` When non-nil, move the mouse pointer over a symbol to show the doc
 
 ## lsp-ui-imenu
 


### PR DESCRIPTION
I found `lsp-ui-doc-show-with-cursor` to be super annoying! It took me ages to realise that it's possible to disable it. So I thought this variable is important enough to add to the README file.