### PR TITLE
Fixed compile warnings, sideline

### DIFF
--- a/lsp-ui-sideline.el
+++ b/lsp-ui-sideline.el
@@ -38,6 +38,11 @@
 (require 'subr-x)
 (require 'face-remap)
 
+(defvar flycheck-display-errors-function)
+(declare-function flycheck-overlay-errors-in "ext:flycheck.el")
+(declare-function flycheck-error-format-message-and-id "ext:flycheck.el")
+(declare-function flycheck-error-level "ext:flycheck.el")
+
 (defgroup lsp-ui-sideline nil
   "Display information for the current line."
   :group 'tools


### PR DESCRIPTION
Since flycheck is currently an optional choice for `lsp-ui`, we need these lines to avoid compile warnings.

#555, #431