### PR TITLE
Move utility function to lsp-ui-util module

### DIFF
--- a/lsp-ui-sideline.el
+++ b/lsp-ui-sideline.el
@@ -30,6 +30,7 @@
 
 ;;; Code:
 
+(require 'lsp-ui-util)
 (require 'lsp-protocol)
 (require 'lsp-mode)
 (require 'flycheck nil 'noerror)
@@ -304,19 +305,6 @@ is set to t."
          (--any (and (string= (overlay-get it 'symbol) symbol)
                      (string= (overlay-get it 'info) info))
                 lsp-ui-sideline--ovs))))
-
-;; TODO: Move this function to `util' module.
-(defun lsp-ui-util-line-number-display-width ()
-  "Safe way to get value from function `line-number-display-width'."
-  (if (bound-and-true-p display-line-numbers-mode)
-      ;; For some reason, function `line-number-display-width' gave
-      ;; us error `args-out-of-range' even we do not pass anything towards
-      ;; to it function. See the following links,
-      ;;
-      ;; - https://github.com/emacs-lsp/lsp-ui/issues/294
-      ;; - https://github.com/emacs-lsp/lsp-ui/issues/533 (duplicate)
-      (+ (or (ignore-errors (line-number-display-width)) 0) 2)
-    0))
 
 (defun lsp-ui-sideline--margin-width ()
   (+ (if fringes-outside-margins right-margin-width 0)

--- a/lsp-ui-util.el
+++ b/lsp-ui-util.el
@@ -36,5 +36,17 @@
   "Safely kill the TIMER."
   (when (timerp timer) (cancel-timer timer)))
 
+(defun lsp-ui-util-line-number-display-width ()
+  "Safe way to get value from function `line-number-display-width'."
+  (if (bound-and-true-p display-line-numbers-mode)
+      ;; For some reason, function `line-number-display-width' gave
+      ;; us error `args-out-of-range' even we do not pass anything towards
+      ;; to it function. See the following links,
+      ;;
+      ;; - https://github.com/emacs-lsp/lsp-ui/issues/294
+      ;; - https://github.com/emacs-lsp/lsp-ui/issues/533 (duplicate)
+      (+ (or (ignore-errors (line-number-display-width)) 0) 2)
+    0))
+
 (provide 'lsp-ui-util)
 ;;; lsp-ui-util.el ends here


### PR DESCRIPTION
Simple patch that moves `lsp-ui-util-line-number-display-width ` to `lsp-ui-util.el` file.