### PR TITLE
render doc string with extracted language for syntax highlighting

### DIFF
--- a/lsp-ui-doc.el
+++ b/lsp-ui-doc.el
@@ -302,7 +302,7 @@ Because some variables are buffer local.")
        (if (and language (not (string= "text" language)))
            (format "```%s\n%s\n```" language string)
          string))
-      (t (lsp--render-element (lsp-ui-doc--inline-formatted-string string)))))))
+      (t (lsp--render-string (lsp-ui-doc--inline-formatted-string string) language))))))
 
 (defun lsp-ui-doc--filter-marked-string (list-marked-string)
   "Filter the LIST-MARKED-STRING."


### PR DESCRIPTION
if `lsp-ui-doc` is able to extract the language from the marked string, provide
it to `lsp--render-string` so that it will determine the mode for that language and
therefore provide syntax highlighting in the childframe

closes https://github.com/emacs-lsp/lsp-ui/issues/436