### PR TITLE
Fix by language specification

### DIFF
--- a/lsp-ui-doc.el
+++ b/lsp-ui-doc.el
@@ -297,7 +297,6 @@ Because some variables are buffer local.")
                                  (lsp:markup-content-kind marked-string)))
                         language))
           (markdown-hr-display-char nil))
-     (message "--> language: %s" language)
      (cond
       (lsp-ui-doc-use-webkit
        (if (and language (not (string= "text" language)))

--- a/lsp-ui-doc.el
+++ b/lsp-ui-doc.el
@@ -297,12 +297,16 @@ Because some variables are buffer local.")
                                  (lsp:markup-content-kind marked-string)))
                         language))
           (markdown-hr-display-char nil))
+     (message "--> language: %s" language)
      (cond
       (lsp-ui-doc-use-webkit
        (if (and language (not (string= "text" language)))
            (format "```%s\n%s\n```" language string)
          string))
-      (t (lsp--render-string (lsp-ui-doc--inline-formatted-string string) language))))))
+      ;; For other programming languages
+      (language (lsp--render-string (lsp-ui-doc--inline-formatted-string string) language))
+      ;; For default markdown content
+      (t (lsp--render-element (lsp-ui-doc--inline-formatted-string string)))))))
 
 (defun lsp-ui-doc--filter-marked-string (list-marked-string)
   "Filter the LIST-MARKED-STRING."


### PR DESCRIPTION
Just realized the patch from #590 may not work for markdown content. Wrap it only when rendering is occurred!