### PR TITLE
Fix #615: Display the border color of the child frame.

### DIFF
--- a/lsp-ui-doc.el
+++ b/lsp-ui-doc.el
@@ -836,6 +836,8 @@ HEIGHT is the documentation number of lines."
     (set-window-dedicated-p window t)
     ;;(redirect-frame-focus frame (frame-parent frame))
     (set-face-background 'internal-border lsp-ui-doc-border frame)
+    (when (facep 'child-frame-border)
+      (set-face-background 'child-frame-border lsp-ui-doc-border frame))
     (set-face-background 'fringe nil frame)
     (run-hook-with-args 'lsp-ui-doc-frame-hook frame window)
     (when lsp-ui-doc-use-webkit


### PR DESCRIPTION
Fix #615 .

See 
https://github.com/tumashu/posframe/blob/739d8fd1081bdd0d20dee9e437d64df58747b871/posframe.el#L355-L356.