### PR TITLE
[lsp-ui-doc] Prevent overriding face in lines below inline doc

### DIFF
--- a/lsp-ui-doc.el
+++ b/lsp-ui-doc.el
@@ -738,7 +738,6 @@ FN is the function to call on click."
                    (-zip-with 'lsp-ui-doc--inline-zip buffer-strings it)
                    (string-join it "\n")
                    (concat it "\n"))))
-    (add-face-text-property 0 (length merged) 'default t merged)
     merged))
 
 (defun lsp-ui-doc--inline-pos-at (start lines)
@@ -774,6 +773,7 @@ HEIGHT is the documentation number of lines."
           (ov (if (overlayp lsp-ui-doc--inline-ov) lsp-ui-doc--inline-ov
                 (setq lsp-ui-doc--inline-ov (make-overlay start end)))))
     (move-overlay ov start end)
+    (overlay-put ov 'face 'default)
     (overlay-put ov 'display (lsp-ui-doc--inline-merge buffer-string))
     (overlay-put ov 'lsp-ui-doc-inline t)
     (overlay-put ov 'window (selected-window))))


### PR DESCRIPTION
When displaying the doc **inline**, the lines below the documentation loose their format.

This is the code before displaying the inline doc:

![without-doc](https://user-images.githubusercontent.com/1837971/120788812-0d2c2b80-c531-11eb-94a8-4327a9d838e1.png)

After displaying the inline doc, the face of the lines below it reset to default:

![inline-doc](https://user-images.githubusercontent.com/1837971/120788766-ff76a600-c530-11eb-93b4-39741634bada.png)

This PR fixes this problem:

![inline-doc-after-PR](https://user-images.githubusercontent.com/1837971/120788886-259c4600-c531-11eb-97ad-976e66876b70.png)

The problem is the way the the overlay is trying to prevent inheriting the face of the text below. After merging the **buffer-string** and the **doc-string** the `default` face was being applyed to the whole text. 

Instead of this the problem can be solved by applying the `default` face to the overlay.