### PR TITLE
Fix column calculation and displaying sideline in the first line

### DIFF
--- a/lsp-ui-sideline.el
+++ b/lsp-ui-sideline.el
@@ -247,8 +247,9 @@ from user point line."
       (setq pos (lsp-ui-sideline--calc-space win-width str-len index)))
     (if (and up (or (null pos) (and (<= pos 1) lsp-ui-sideline--first-line-pushed)))
         (lsp-ui-sideline--find-line str-len bol eol nil offset)
-      (when (lsp-ui-sideline--first-line-p pos)  ; mark first line push
-        (setq lsp-ui-sideline--first-line-pushed t))
+      (when (and (null lsp-ui-sideline--first-line-pushed)
+                 (lsp-ui-sideline--first-line-p pos))
+        (setq lsp-ui-sideline--first-line-pushed t))  ; mark first line push
       (and pos (or (> pos eol) (< pos bol))
            (push pos lsp-ui-sideline--occupied-lines)
            (list pos (1- index))))))
@@ -259,7 +260,7 @@ from user point line."
   (setq lsp-ui-sideline--tag nil
         lsp-ui-sideline--cached-infos nil
         lsp-ui-sideline--occupied-lines nil
-        lsp-ui-sideline--first-line-pushed nil
+        lsp-ui-sideline--first-line-pushed (lsp-ui-sideline--first-line-p (point))
         lsp-ui-sideline--ovs nil))
 
 (defun lsp-ui-sideline--extract-info (contents)

--- a/lsp-ui-sideline.el
+++ b/lsp-ui-sideline.el
@@ -144,7 +144,8 @@ This can be used to insert, for example, an unicode character: 💡")
 (defvar-local lsp-ui-sideline--first-line-pushed nil
   "Record weather if we display sideline in the first line.
 
-If we do, then sideline will always look downward instead of the upward direction.
+If we do, then sideline will always look downward instead of the upward
+direction.
 
 This prevent sideline displays below than the first line, which it will cause
 weird looking user interface.")

--- a/lsp-ui-sideline.el
+++ b/lsp-ui-sideline.el
@@ -215,6 +215,7 @@ INDEX is the line number (relative to the current line)."
     (unless (member eol lsp-ui-sideline--occupied-lines)
       (save-excursion
         (goto-char eol)
+        (end-of-line)
         (when (>= (- win-width (current-column)) str-len)
           eol)))))
 
@@ -236,11 +237,7 @@ from user point line."
     (while (and (null pos) (<= (abs index) 30))
       (setq index (if up (1- index) (1+ index)))
       (setq pos (lsp-ui-sideline--calc-space win-width str-len index)))
-    (if (and up (or (null pos)
-                    ;; This will avoid sideline not showing on the first
-                    ;; line of the buffer.
-                    (and (lsp-ui-sideline--first-line-p pos)
-                         (lsp-ui-sideline--first-line-p (point)))))
+    (if (and up (null pos))
         (lsp-ui-sideline--find-line str-len bol eol nil offset)
       (and pos (or (> pos eol) (< pos bol))
            (push pos lsp-ui-sideline--occupied-lines)
@@ -574,7 +571,7 @@ Argument HEIGHT is an actual image height in pixel."
           (or (-some-> range (lsp-get :start) (lsp-get :line) (= line))
               (-some-> range (lsp-get :end) (lsp-get :line) (= line))))
         (lsp--get-buffer-diagnostics))
-       (apply 'vector)))
+    (apply 'vector)))
 
 (defun lsp-ui-sideline--run (&optional buffer bol eol this-line)
   "Show information (flycheck + lsp).

--- a/lsp-ui-sideline.el
+++ b/lsp-ui-sideline.el
@@ -237,7 +237,7 @@ from user point line."
     (while (and (null pos) (<= (abs index) 30))
       (setq index (if up (1- index) (1+ index)))
       (setq pos (lsp-ui-sideline--calc-space win-width str-len index)))
-    (if (and up (null pos))
+    (if (and up (or (null pos) (<= pos 1)))
         (lsp-ui-sideline--find-line str-len bol eol nil offset)
       (and pos (or (> pos eol) (< pos bol))
            (push pos lsp-ui-sideline--occupied-lines)
@@ -538,7 +538,7 @@ Argument HEIGHT is an actual image height in pixel."
               (ov (and pos-ov (make-overlay (car pos-ov) (car pos-ov)))))
         (when pos-ov
           (overlay-put ov 'after-string string)
-          (overlay-put ov 'before-string " ")
+          (overlay-put ov 'before-string "")
           (overlay-put ov 'kind 'actions)
           (overlay-put ov 'position (car pos-ov))
           (push ov lsp-ui-sideline--ovs))))))


### PR DESCRIPTION
This patch fix the following issue,

* Fix the sufficient space calculation
* Fix logic when displaying sideline in the first line