### PR TITLE
lsp-ui-doc--hide-frame: dont clear doc buffer on hide

### DIFF
--- a/lsp-ui-doc.el
+++ b/lsp-ui-doc.el
@@ -403,8 +403,6 @@ We don't extract the string that `lps-line' is already displaying."
   (lsp-ui-util-safe-delete-overlay lsp-ui-doc--inline-ov)
   (lsp-ui-util-safe-delete-overlay lsp-ui-doc--highlight-ov)
   (when-let ((frame (lsp-ui-doc--get-frame)))
-    (unless lsp-ui-doc-use-webkit
-      (lsp-ui-doc--with-buffer (erase-buffer)))
     (when (frame-visible-p frame)
       (make-frame-invisible frame))))
 


### PR DESCRIPTION
We've already clear the doc buffer on show so no need to clear the doc buffer on hide, the `webkit` version is also not doing that.

Don't clear the doc buffer on hide provides another advantage when triggers `lsp-ui-doc--open-markdown-link` with the keyboard.
In that case, there's a race condition that `(point)` is calculated after the doc buffer has been cleared, thus there's no link to follow.
Not clear the doc buffer on hide resolve that.