### PR TITLE
Fix documentation styling when using webkit

### DIFF
--- a/lsp-ui-doc.el
+++ b/lsp-ui-doc.el
@@ -113,6 +113,11 @@ This only takes effect when `lsp-ui-doc-position' is 'top or 'bottom."
   :type 'integer
   :group 'lsp-ui-doc)
 
+(defcustom lsp-ui-doc-webkit-max-width-px 600
+  "Maximum width in pixels for the webkit frame."
+  :type 'integer
+  :group 'lsp-ui-doc)
+
 (defcustom lsp-ui-doc-max-height 13
   "Maximum number of lines in the frame."
   :type 'integer
@@ -305,7 +310,9 @@ Because some variables are buffer local.")
           (markdown-hr-display-char nil))
      (cond
       (lsp-ui-doc-use-webkit
-       (if (and language (not (string= "text" language)))
+       (if (and language
+                (not (string= "text" language))
+                (not (string= lsp/markup-kind-markdown language)))
            (format "```%s\n%s\n```" language string)
          string))
       ;; For other programming languages
@@ -364,8 +371,15 @@ We don't extract the string that `lps-line' is already displaying."
         (xwidget-webkit-mode)
         (xwidget-webkit-goto-uri (xwidget-at 1)
                                  lsp-ui-doc-webkit-client-path)
+        (lsp-ui-doc--webkit-set-width)
         (lsp-ui-doc--webkit-set-background)
         (lsp-ui-doc--webkit-set-foreground)))))
+
+(defun lsp-ui-doc--webkit-set-width ()
+  "Set webkit document max-width CSS property."
+  (lsp-ui-doc--webkit-execute-script
+   (format "document.documentElement.style.setProperty('--webkit-max-width-px', %d + 'px');"
+           lsp-ui-doc-webkit-max-width-px)))
 
 (defun lsp-ui-doc--webkit-set-background ()
   "Set background color of the WebKit widget."

--- a/lsp-ui-doc.html
+++ b/lsp-ui-doc.html
@@ -7,12 +7,21 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/2.10.0/github-markdown.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.13.1/styles/default.min.css">
     <style>
+
+     :root {
+       --webkit-max-width-px: 600px;
+     }
+
      .markdown-body {
        box-sizing: border-box;
-       min-width: 400px;
-       max-width: 600px;
+       min-width: var(--webkit-max-width-px);
+       max-width: var(--webkit-max-width-px);
        margin: 0 auto;
        padding: 10px;
+     }
+
+     .markdown-body pre code {
+       white-space: pre-wrap;
      }
     </style>
   </head>


### PR DESCRIPTION
Some language servers like (haskel-language-server, rust-analyzer) returns `MarkupContent { kind: "markdown", value: "..." }` for documentation. However when rendering it in Webkit it was wrapped in ` ```markdown <contents> ``` ` one more time, confusing the JS library `showdown`.

## This PR
- Removes the ` ```markdown <contents> ``` ` wrapper when `MarkupContent.kind == "markdown"`
- Create a CSS variable for webkit width size that is configurable from emacs.
- Add `white-space: pre-wrap` for `<code>` elements, so that the lines are wrapped and don't overflow.

# Results
- Tested with `haskell-language-server, rust-analyzer`

## Before

### Haskell
<img width="541" alt="Screen Shot 2021-07-25 at 0 55 41" src="https://user-images.githubusercontent.com/1908865/126874400-480f08bf-52e5-45ce-b1c2-7880451bfb9a.png" style="display:inline-block;">

### Rust
<img width="577" alt="Screen Shot 2021-07-25 at 0 58 29" src="https://user-images.githubusercontent.com/1908865/126874405-b1036a1e-1ebf-4496-af5b-3c074dafb480.png">

## After

### Haskell
<img width="669" alt="Screen Shot 2021-07-25 at 1 01 58" src="https://user-images.githubusercontent.com/1908865/126874413-b37b296d-d0c6-424b-93d2-cfd013575fb7.png">

### Rust
<img width="714" alt="Screen Shot 2021-07-25 at 1 02 28" src="https://user-images.githubusercontent.com/1908865/126874418-78d16e21-f0ac-43c5-9e22-50093294f206.png">

