### PR TITLE
More robust way to locate the resource dir

### DIFF
--- a/lsp-ui.el
+++ b/lsp-ui.el
@@ -38,7 +38,7 @@
 (require 'find-func)
 
 (defconst lsp-ui-resources-dir
-  (--> (find-library-name "lsp-ui")
+  (--> (or load-file-name (buffer-file-name))
        (file-name-directory it)
        (expand-file-name "resources" it)
        (file-name-as-directory it)


### PR DESCRIPTION
Hi,
There is an error in my local when active lsp-ui:
>Error running timer: (error "Can’t find library lsp-ui")

The root cause is lsp-ui will call `(find-library-name "lsp-ui")` but there is only `lsp-ui.elc` in my local (the `lsp-ui.el` is deleted for saving storage), then the error happened.
This patch will do better than the original way.
Please help review and merge this PR. 
Thanks
