### PR TITLE
lsp-ui-doc-glance: no effect when lsp-ui-doc-show-with-cursor is nil

### DIFF
--- a/lsp-ui-doc.el
+++ b/lsp-ui-doc.el
@@ -1166,7 +1166,8 @@ It is supposed to be called from `lsp-ui--toggle'"
 (defun lsp-ui-doc-glance ()
   "Trigger display hover information popup and hide it on next typing."
   (interactive)
-  (lsp-ui-doc--make-request)
+  (let ((lsp-ui-doc-show-with-cursor t))
+    (lsp-ui-doc--make-request))
   (when lsp-ui-doc--unfocus-frame-timer
     (cancel-timer lsp-ui-doc--unfocus-frame-timer))
   (add-hook 'post-command-hook 'lsp-ui-doc--glance-hide-frame))


### PR DESCRIPTION
I'd like to use `lsp-ui-doc-glance` while having `lsp-ui-doc-show-with-cursor` set to nil.  Not sure if this is the correct fix, so please help.