### PR TITLE
Disable noisy features

### DIFF
--- a/lsp-ui-doc.el
+++ b/lsp-ui-doc.el
@@ -62,7 +62,7 @@
   :link '(custom-manual "(lsp-ui-doc) Top")
   :link '(info-link "(lsp-ui-doc) Customizing"))
 
-(defcustom lsp-ui-doc-enable nil
+(defcustom lsp-ui-doc-enable t
   "Whether or not to enable lsp-ui-doc."
   :type 'boolean
   :group 'lsp-ui)
@@ -72,7 +72,7 @@
   :type 'boolean
   :group 'lsp-ui-doc)
 
-(defcustom lsp-ui-doc-show-with-cursor t
+(defcustom lsp-ui-doc-show-with-cursor nil
   "Move the cursor over a symbol to show its documentation."
   :type 'boolean
   :group 'lsp-ui-doc)

--- a/lsp-ui-doc.el
+++ b/lsp-ui-doc.el
@@ -62,7 +62,7 @@
   :link '(custom-manual "(lsp-ui-doc) Top")
   :link '(info-link "(lsp-ui-doc) Customizing"))
 
-(defcustom lsp-ui-doc-enable t
+(defcustom lsp-ui-doc-enable nil
   "Whether or not to enable lsp-ui-doc."
   :type 'boolean
   :group 'lsp-ui)

--- a/lsp-ui-sideline.el
+++ b/lsp-ui-sideline.el
@@ -77,7 +77,7 @@
   :type 'boolean
   :group 'lsp-ui-sideline)
 
-(defcustom lsp-ui-sideline-show-code-actions t
+(defcustom lsp-ui-sideline-show-code-actions nil
   "Whether to show code actions in sideline."
   :type 'boolean
   :group 'lsp-ui-sideline)


### PR DESCRIPTION
This PR tries to reduce some noise features that confuses a lot of lsp-mode/ui users.

- Disable `lsp-ui-sideline-show-code-actions`. We implemented almost a year ago the diagnostics on the modeline as a bulb icon, this is what most editors have as a way to show there are code actions available + the count instead of showing on user's code a lot of lines.
We can see how confuse it becomes for servers with more than 4-5 code actions:
![image](https://user-images.githubusercontent.com/7820865/144887095-cedcbdd1-5cb9-402f-85cb-6a61c58587e3.png)

- Disable `lsp-ui-doc-enable`, this one is one of the worst to be enable by default IMO, if this one is enabled we show the docs when the cursor is in a symbol, this is different from all other editors which only show the docs if user hover the mouse OR use a keybinding specific. It's a cool feature, but to be used manually by user IMO.

We often receive complains about lsp-mode being too noisy, I know that turning and editor into a IDE with lsp is something that adds some noises indeed and most of then makes sense IMO, but I think those 2 are something that makes harder for users indeed. 

c/c @yyoncho 