### PR TITLE
Add additional info to lsp-ui-doc-enable docs

### DIFF
--- a/lsp-ui-doc.el
+++ b/lsp-ui-doc.el
@@ -63,7 +63,8 @@
   :link '(info-link "(lsp-ui-doc) Customizing"))
 
 (defcustom lsp-ui-doc-enable t
-  "Whether or not to enable lsp-ui-doc."
+  "Whether or not to enable lsp-ui-doc.
+Displays documentation of the symbol at point on hover. This only takes effect when a buffer is started."
   :type 'boolean
   :group 'lsp-ui)
 


### PR DESCRIPTION
I initially didn't expect `lsp-ui-doc-enable` to only be read when the buffer was started, I thought it would take effect for buffers that were already running.

Information about this only taking effect on buffer start is taken from https://github.com/emacs-lsp/lsp-ui/issues/625#issuecomment-863548628