### PR TITLE
Respect lsp-ui-doc-delay when mousing over text.

### DIFF
--- a/lsp-ui-doc.el
+++ b/lsp-ui-doc.el
@@ -1081,7 +1081,7 @@ Argument WIN is current applying window."
       (when same-win
         (setq lsp-ui-doc--last-event point
               lsp-ui-doc--timer-mouse-movement
-              (run-with-idle-timer 0.5 nil 'lsp-ui-doc--mouse-display))))))
+              (run-with-idle-timer lsp-ui-doc-delay nil 'lsp-ui-doc--mouse-display))))))
 
 (defun lsp-ui-doc--disable-mouse-on-prefix nil
   (and (bound-and-true-p lsp-ui-doc-mode)


### PR DESCRIPTION
The delay here was hardcoded to 0.5. I would have expected this to be commensurate with the lsp-ui-doc-delay setting.

Fixes https://github.com/emacs-lsp/lsp-ui/issues/664