### PR TITLE
Prevent reference count string from jumping into the next line because of the window divider's width not taken into account

### DIFF
--- a/lsp-ui-peek.el
+++ b/lsp-ui-peek.el
@@ -319,7 +319,12 @@ XREFS is a list of references/definitions."
                                 'face 'lsp-ui-peek-filename
                                 'file filename
                                 'xrefs xrefs)
-                    (propertize " " 'display `(space :align-to (- right-fringe ,(1+ (length len-str)))))
+                    (propertize " " 'display `(space :align-to (- right-fringe
+                                                                  ;; Account for Emacs TTY's window divider
+                                                                  ;; Without this leeway, the reference count
+                                                                  ;; string goes to next line - impairs readability
+                                                                  ,(if (display-graphic-p) 0 1)
+                                                                  ,(1+ (length len-str)))))
                     (propertize len-str 'face 'lsp-ui-peek-filename))
             lsp-ui-peek--list)))
   (setq lsp-ui-peek--list (nreverse lsp-ui-peek--list))


### PR DESCRIPTION
Note that the leeway is hardcoded to 1 because that's just how it is in
TTY. TTY ignores window-divider-width

Before the code change:
![image](https://user-images.githubusercontent.com/15933322/147627171-94ded50a-5886-4011-8885-01e0fada6912.png)

After the code change:
![image](https://user-images.githubusercontent.com/15933322/147627147-b2de7add-f88c-4628-a03f-a2fa6639577f.png)

