### PR TITLE
Also bind "<tab>" in addition to "TAB" for lsp-ui-peek

### DIFF
--- a/lsp-ui-peek.el
+++ b/lsp-ui-peek.el
@@ -549,6 +549,7 @@ XREFS is a list of references/definitions."
     (define-key map (kbd "p") 'lsp-ui-peek--select-prev)
     (define-key map (kbd "<up>") 'lsp-ui-peek--select-prev)
     (define-key map (kbd "TAB") 'lsp-ui-peek--toggle-file)
+    (define-key map (kbd "<tab>") 'lsp-ui-peek--toggle-file)
     (define-key map (kbd "q") 'lsp-ui-peek--abort)
     (define-key map (kbd "RET") 'lsp-ui-peek--goto-xref)
     (define-key map (kbd "M-RET") 'lsp-ui-peek--goto-xref-other-window)


### PR DESCRIPTION
When `"<tab>"` (which is the same as `[tab]` I believe) is not bound in `lsp-ui-peek-mode-map`, other keymaps that bind `"<tab>"` can grab a Tab-key press before it is handled as `"TAB"` by lsp-ui-peek. Therefore, also bind to `"<tab>"`/`[tab]` so that the key is always handled by lsp-ui-peek when the peek-window is open. This should only make a difference in GUI emacs, as console emacs can/does not differentiate between `"<tab>"` and `"TAB"`.

I originally discovered & reported this in doom-emacs, and the fix given here is basically what doom's maintainer recommended, see the (short) bug report here: https://github.com/hlissner/doom-emacs/issues/5028

Disclosure: I only tested the doom-version of the bugfix given in the bug report linked above, and it fixed the issue. I did *not* test *this* PR locally; I'm relying on CI/reviews to make sure nothing breaks, as this looks like a small change to me.