### PR TITLE
Move triggering of lsp-ui-doc auto-hide to after display

### DIFF
--- a/lsp-ui-doc.el
+++ b/lsp-ui-doc.el
@@ -958,7 +958,10 @@ BUFFER is the buffer where the request has been made."
            (-some->> contents
              lsp-ui-doc--extract
              (replace-regexp-in-string "\r" "")
-             (replace-regexp-in-string " " " "))))
+             (replace-regexp-in-string " " " ")))
+          (when lsp-ui-doc--unfocus-frame-timer
+            (cancel-timer lsp-ui-doc--unfocus-frame-timer))
+          (add-hook 'post-command-hook 'lsp-ui-doc--glance-hide-frame))
       (lsp-ui-doc--hide-frame))))
 
 (defun lsp-ui-doc--delete-frame ()
@@ -1176,10 +1179,7 @@ It is supposed to be called from `lsp-ui--toggle'"
   "Trigger display hover information popup and hide it on next typing."
   (interactive)
   (let ((lsp-ui-doc-show-with-cursor t))
-    (lsp-ui-doc--make-request))
-  (when lsp-ui-doc--unfocus-frame-timer
-    (cancel-timer lsp-ui-doc--unfocus-frame-timer))
-  (add-hook 'post-command-hook 'lsp-ui-doc--glance-hide-frame))
+    (lsp-ui-doc--make-request)))
 
 (define-minor-mode lsp-ui-doc-frame-mode
   "Marker mode to add additional key bind for lsp-ui-doc-frame."


### PR DESCRIPTION
This is my attempt to address #695.

As well fixing auto-hide for docs explicitly invoked via `lsp-ui-doc-glance`, this adds post-command clearing to both `lsp-ui-doc-show-with-mouse` and `lsp-ui-doc-show-with-cursor`. That seems consistent to me, so I don't think it presents a problem.

- Maybe there should be a separate `lsp-ui-doc-auto-hide` setting to disable auto-hiding for all three of these mechanisms?

Fixes: #695
