### PR TITLE
Doc wrap now adjusts to text scale

### DIFF
--- a/lsp-ui-doc.el
+++ b/lsp-ui-doc.el
@@ -460,6 +460,10 @@ We don't extract the string that `lps-line' is already displaying."
     (xwidget-resize (lsp-ui-doc--webkit-get-xwidget) offset-width offset-height))
   (lsp-ui-doc--move-frame (lsp-ui-doc--get-frame)))
 
+(defun lsp-ui-doc--scale-column-width (width)
+  "Return WIDTH adjusted relative to the text scale."
+  (floor (/ width (expt 1.1 lsp-ui-doc-text-scale-level))))
+
 (defun lsp-ui-doc--resize-buffer ()
   "If the buffer's width is larger than the current frame, resize it."
   (if lsp-ui-doc-use-webkit
@@ -468,7 +472,7 @@ We don't extract the string that `lps-line' is already displaying."
        'lsp-ui-doc--webkit-resize-callback)
 
     (let* ((frame-width (frame-width))
-           (fill-column (min lsp-ui-doc-max-width (- frame-width 5))))
+           (fill-column (lsp-ui-doc--scale-column-width (min lsp-ui-doc-max-width (- frame-width 5)))))
       (when (> (lsp-ui-doc--buffer-width) (min lsp-ui-doc-max-width frame-width))
         (lsp-ui-doc--with-buffer
           (fill-region (point-min) (point-max)))))))
@@ -618,7 +622,7 @@ FN is the function to call on click."
 
 (defun lsp-ui-doc--fill-document ()
   "Better wrap the document so it fits the doc window."
-  (let ((fill-column (- lsp-ui-doc-max-width 5))
+  (let ((fill-column (lsp-ui-doc--scale-column-width (- lsp-ui-doc-max-width 5)))
         start        ; record start for `fill-region'
         first-line)  ; first line in paragraph
     (save-excursion


### PR DESCRIPTION
Fixes #698 
Here we scale the column width with the text scaling, to correctly wrap the lines.

![correct-wrap-large](https://user-images.githubusercontent.com/5475129/162722218-851ceed3-e6d8-4fd5-bc2f-f5646be77baf.png)
![correct-wrap-small](https://user-images.githubusercontent.com/5475129/162722222-bc6c6c3a-b15b-40f6-93cf-543bb48b9cfc.png)
