### PR TITLE
Clear overlay state vars in lsp-ui-doc--hide-frame

### DIFF
--- a/lsp-ui-doc.el
+++ b/lsp-ui-doc.el
@@ -420,10 +420,12 @@ We don't extract the string that `lps-line' is already displaying."
 
 (defun lsp-ui-doc--hide-frame (&optional _win)
   "Hide the frame."
-  (setq lsp-ui-doc--bounds nil
-        lsp-ui-doc--from-mouse nil)
   (lsp-ui-util-safe-delete-overlay lsp-ui-doc--inline-ov)
   (lsp-ui-util-safe-delete-overlay lsp-ui-doc--highlight-ov)
+  (setq lsp-ui-doc--bounds nil
+        lsp-ui-doc--from-mouse nil
+        lsp-ui-doc--inline-ov nil
+        lsp-ui-doc--highlight-ov nil)
   (when-let ((frame (lsp-ui-doc--get-frame)))
     (when (frame-visible-p frame)
       (make-frame-invisible frame))))


### PR DESCRIPTION
Fixes #695

Minimal fix. See #711 for more discussion. Note that I also tested @kiennq  speculation that this method may have a performance penalty compared to using an additional `overlay-buffer` condition inside `lsp-ui-doc--glance-hide-frame`, and found that this PR actually improves the speed of doc display by a significant factor. Profiling function:

```lisp
(defun my-time-lsp-ui-doc-show()
  (interactive)
  (profiler-start 'cpu)
  (message "Starting")
  (let ((start-time (current-time))
        (iterations 1000))
    (dotimes (counter iterations)
      (lsp-ui-doc-show)
      (lsp-ui-doc-hide))
    (let* ((elapsed (float-time (time-subtract (current-time) start-time)))
           (iteration-time (/ elapsed iterations)))
      (profiler-stop)
      (message "Finished %d iterations in %.3fs (%.3fs / iteration)" iterations elapsed iteration-time))))
```

Master:
```
Finished 1000 iterations in 16.885s (0.017s / iteration)
```

This PR:
```
Finished 1000 iterations in 9.936s (0.010s / iteration)
```


