### PR TITLE
Fix `lsp-ui-imenu` sub-title ordering.

### DIFF
--- a/lsp-ui-imenu.el
+++ b/lsp-ui-imenu.el
@@ -202,7 +202,7 @@
   (let ((ov (make-overlay (point) (point)))
         (title-color (lsp-ui-imenu--get-color (+ color-index depth))))
     (overlay-put
-     ov 'after-string
+     ov 'before-string
      (concat (lsp-ui-imenu--pad " " padding bars depth color-index t is-last)
              (propertize title 'face `(:foreground ,title-color))
              (propertize "\n" 'face '(:height 1))))))
@@ -220,31 +220,30 @@ DEPTH is the depth of the items in the index tree, starting from 0.
 COLOR-INDEX is the index of the color of the leftmost bar.
 
 Return the updated COLOR-INDEX."
-  (let ((len (length items)))
-    (--each-indexed items
-      (let ((is-last (= (1+ it-index) len)))
-        (if (imenu--subalist-p it)
-            (-let* (((sub-title . entries) it))
-              (if (= depth 0)
-                  (lsp-ui-imenu--put-toplevel-title sub-title color-index)
-                (lsp-ui-imenu--put-subtitle sub-title padding bars depth color-index is-last))
-              (when (and is-last (> depth 0))
-                (aset bars (1- depth) nil))
-              (let ((lsp-ui-imenu-kind-position (if (> depth 0) 'top
-                                                  lsp-ui-imenu-kind-position)))
-                (lsp-ui-imenu--insert-items sub-title
-                                            entries
-                                            padding
-                                            bars
-                                            (1+ depth)
-                                            color-index))
-              (when (and is-last (> depth 0))
-                (aset bars (1- depth) t))
-              (when (= depth 0)
-                (setq color-index (1+ color-index))))
-          (insert (lsp-ui-imenu--make-line title it-index it
-                                           padding bars depth color-index
-                                           is-last))))))
+  (--each-indexed items
+    (let ((is-last (= (1+ it-index) (length items))))
+      (if (imenu--subalist-p it)
+          (-let* (((sub-title . entries) it))
+            (if (= depth 0)
+                (lsp-ui-imenu--put-toplevel-title sub-title color-index)
+              (lsp-ui-imenu--put-subtitle sub-title padding bars depth color-index is-last))
+            (when (and is-last (> depth 0))
+              (aset bars (1- depth) nil))
+            (let ((lsp-ui-imenu-kind-position (if (> depth 0) 'top
+                                                lsp-ui-imenu-kind-position)))
+              (lsp-ui-imenu--insert-items sub-title
+                                          entries
+                                          padding
+                                          bars
+                                          (1+ depth)
+                                          color-index))
+            (when (and is-last (> depth 0))
+              (aset bars (1- depth) t))
+            (when (= depth 0)
+              (setq color-index (1+ color-index))))
+        (insert (lsp-ui-imenu--make-line title it-index it
+                                         padding bars depth color-index
+                                         is-last)))))
   color-index)
 
 (defun lsp-ui-imenu--get-padding (items)

--- a/lsp-ui-imenu.el
+++ b/lsp-ui-imenu.el
@@ -183,7 +183,10 @@
 
 (defun lsp-ui-imenu--put-separator nil
   (let ((ov (make-overlay (point) (point))))
-    (overlay-put ov 'after-string (propertize "\n" 'face '(:height 0.6)))))
+    (overlay-put ov 'after-string (propertize "\n" 'face '(:height 0.6)))
+    (overlay-put ov 'priority 0)))
+
+(defvar-local overlay-priority 0)
 
 (defun lsp-ui-imenu--put-toplevel-title (title color-index)
   (if (eq lsp-ui-imenu-kind-position 'top)
@@ -194,7 +197,8 @@
          (concat (propertize "\n" 'face '(:height 0.6))
                  (propertize title 'face `(:foreground ,color))
                  "\n"
-                 (propertize "\n" 'face '(:height 0.6)))))
+                 (propertize "\n" 'face '(:height 0.6))))
+	(overlay-put ov 'priority (setq overlay-priority (1- overlay-priority))))
     ;; Left placement, title is put with the first sub item. Only put a separator here.
     (lsp-ui-imenu--put-separator)))
 
@@ -202,10 +206,11 @@
   (let ((ov (make-overlay (point) (point)))
         (title-color (lsp-ui-imenu--get-color (+ color-index depth))))
     (overlay-put
-     ov 'before-string
+     ov 'after-string
      (concat (lsp-ui-imenu--pad " " padding bars depth color-index t is-last)
              (propertize title 'face `(:foreground ,title-color))
-             (propertize "\n" 'face '(:height 1))))))
+             (propertize "\n" 'face '(:height 1))))
+    (overlay-put ov 'priority (setq overlay-priority (1- overlay-priority)))))
 
 (defun lsp-ui-imenu--insert-items (title items padding bars depth color-index)
   "Insert ITEMS for TITLE.


### PR DESCRIPTION
The `lsp-ui-imenu` displayed items in the wrong hierarchy, which was previously found in Issues [#474](https://github.com/emacs-lsp/lsp-ui/issues/474), [#527](https://github.com/emacs-lsp/lsp-ui/issues/527) [#632](https://github.com/emacs-lsp/lsp-ui/issues/632), and [#714](https://github.com/emacs-lsp/lsp-ui/issues/714), and in Java from my experience:
<img src=https://user-images.githubusercontent.com/54956345/174658075-a494402d-97fb-4224-9205-63b2725f93b1.png width="50%"/>

I believe I found a quick fix, which arose due to multiple elisp overlays being used in a recursive function.

In any case, this is the result after my quick fix:
<img src=https://user-images.githubusercontent.com/54956345/174658587-f3ce9a4d-4062-4afb-b4c7-f6c6bd1e2f77.png width="50%"/>

(Also, the multi-line change in the pull-request is just me removing a redundant `let` block)