### PR TITLE
Allow lsp UI doc hide from focused frame

### DIFF
--- a/lsp-ui-doc.el
+++ b/lsp-ui-doc.el
@@ -1178,6 +1178,7 @@ It is supposed to be called from `lsp-ui--toggle'"
 (defun lsp-ui-doc-hide ()
   "Hide hover information popup."
   (interactive)
+  (lsp-ui-doc-unfocus-frame) ;; In case focus is in doc frame
   (lsp-ui-doc--hide-frame))
 
 (defun lsp-ui-doc-glance ()
@@ -1200,6 +1201,7 @@ It is supposed to be called from `lsp-ui--toggle'"
   (interactive)
   (when-let* ((frame (lsp-ui-doc--get-frame))
               (visible (lsp-ui-doc--frame-visible-p)))
+    (remove-hook 'post-command-hook 'lsp-ui-doc--hide-frame)
     (set-frame-parameter frame 'lsp-ui-doc--no-focus nil)
     (set-frame-parameter frame 'cursor-type t)
     (lsp-ui-doc--with-buffer

--- a/lsp-ui-doc.el
+++ b/lsp-ui-doc.el
@@ -64,7 +64,8 @@
 
 (defcustom lsp-ui-doc-enable t
   "Whether or not to enable lsp-ui-doc.
-Displays documentation of the symbol at point on hover. This only takes effect when a buffer is started."
+Displays documentation of the symbol at point on hover.  This only
+takes effect when a buffer is started."
   :type 'boolean
   :group 'lsp-ui)
 


### PR DESCRIPTION
Previously, calling `lsp-ui-doc-hide-frame` would not hide the frame when the user focus was inside the frame.

Now in your use-package you can have something like:
```
  :bind (:map lsp-ui-doc-frame-mode-map
              ("q" . 'lsp-ui-doc-hide)
              ("u" . 'lsp-ui-doc-unfocus-frame))
```

This is regardless of whether the doc frame was instigated by `lsp-ui-doc-show`, `lsp-ui-doc-glance`, or cursor/mouse hover.

Fixes #726 

@kiennq 