### PR TITLE
Use lsp-feature? to check for hover capability instead of lsp--capability

### DIFF
--- a/lsp-ui-doc.el
+++ b/lsp-ui-doc.el
@@ -930,7 +930,7 @@ HEIGHT is the documentation number of lines."
   (when (and lsp-ui-doc-show-with-cursor
              (not (memq this-command lsp-ui-doc--ignore-commands))
              (not (bound-and-true-p lsp-ui-peek-mode))
-             (lsp--capability "hoverProvider"))
+             (lsp-feature? "textDocument/hover"))
     (-if-let (bounds (or (and (symbol-at-point) (bounds-of-thing-at-point 'symbol))
                          (and (looking-at "[[:graph:]]") (cons (point) (1+ (point))))))
         (unless (and (equal lsp-ui-doc--bounds bounds) (not lsp-ui-doc--hide-on-next-command))


### PR DESCRIPTION
lsp--capability doesn't correctly pickup hover capability when using omnisharp. lsp-feature? does. This fix lsp-ui-doc when using omnisharp

Related: https://github.com/emacs-lsp/lsp-mode/issues/3735