### PR TITLE
Fix `peek--get-references` for `lsp-use-plists`

### DIFF
--- a/lsp-ui-peek.el
+++ b/lsp-ui-peek.el
@@ -726,7 +726,10 @@ references.  The function returns a list of `ls-xref-item'."
 Returns item(s)."
   (-when-let* ((locs (lsp-request method params))
                (locs (if (listp locs)
-                         locs
+                         (if (symbolp (car locs))
+                             ;; A single plist was returned
+                             (list locs)
+                           locs)
                        (if (vectorp locs)
                            (append locs nil)
                          (list locs)))))


### PR DESCRIPTION
This fixes `lsp-ui-peek-find-definitions/references` when `lsp-use-plists` is `t` and a single item is returned by the server.

#### Copy of commit msg
When `lsp-use-plists` is t, `lsp-request` returns a single plist (of form `(:key val ...)` or a list of plists.

Previously, when `lsp-use-plists` was t and a single plist was returned, the plist wasn't wrapped into a list, causing the subsequent code to fail.