### PR TITLE
Fix/improve declaration handling in lsp-ui-peek-find-references

### DIFF
--- a/lsp-ui-peek.el
+++ b/lsp-ui-peek.el
@@ -604,7 +604,9 @@ PARAM is the request params."
   "Find references to the IDENTIFIER at point."
   (interactive)
   (lsp-ui-peek--find-xrefs (symbol-at-point) "textDocument/references"
-                           (append extra (lsp--make-reference-params nil include-declaration))))
+                           (append extra (lsp--make-reference-params
+                                          nil
+                                          (not include-declaration)))))
 
 (defun lsp-ui-peek-find-definitions (&optional extra)
   "Find definitions to the IDENTIFIER at point."

--- a/lsp-ui-peek.el
+++ b/lsp-ui-peek.el
@@ -601,8 +601,11 @@ PARAM is the request params."
       (lsp-ui-peek--show xrefs))))
 
 (defun lsp-ui-peek-find-references (&optional include-declaration extra)
-  "Find references to the IDENTIFIER at point."
-  (interactive)
+  "Find references to the IDENTIFIER at point.
+
+With a prefix argument, or if INCLUDE-DECLARATION is non-nil,
+includes the declaration of the identifier in the results."
+  (interactive "P")
   (lsp-ui-peek--find-xrefs (symbol-at-point) "textDocument/references"
                            (append extra (lsp--make-reference-params
                                           nil

--- a/lsp-ui.el
+++ b/lsp-ui.el
@@ -127,10 +127,10 @@ Both should have the form (FILENAME LINE COLUMN)."
         (< (cadr x) (cadr y))
       (< (caddr x) (caddr y)))))
 
-(defun lsp-ui--reference-triples (include-declaration)
+(defun lsp-ui--reference-triples (exclude-declaration)
   "Return references as a list of (FILENAME LINE COLUMN) triples given EXTRA."
   (let ((refs (lsp-request "textDocument/references"
-                           (lsp--make-reference-params nil include-declaration))))
+                           (lsp--make-reference-params nil exclude-declaration))))
     (sort
      (mapcar
       (-lambda ((&Location :uri :range (&Range :start (&Position :line :character))))
@@ -139,11 +139,11 @@ Both should have the form (FILENAME LINE COLUMN)."
      #'lsp-ui--location<)))
 
 ;; TODO Make it efficient
-(defun lsp-ui-find-next-reference (&optional include-declaration)
+(defun lsp-ui-find-next-reference (&optional exclude-declaration)
   "Find next reference of the symbol at point."
   (interactive)
   (let* ((cur (list buffer-file-name (1- (line-number-at-pos)) (- (point) (line-beginning-position))))
-         (refs (lsp-ui--reference-triples include-declaration))
+         (refs (lsp-ui--reference-triples exclude-declaration))
          (idx -1)
          (res (-first (lambda (ref) (cl-incf idx) (lsp-ui--location< cur ref)) refs)))
     (if res
@@ -156,11 +156,11 @@ Both should have the form (FILENAME LINE COLUMN)."
       (cons 0 0))))
 
 ;; TODO Make it efficient
-(defun lsp-ui-find-prev-reference (&optional include-declaration)
+(defun lsp-ui-find-prev-reference (&optional exclude-declaration)
   "Find previous reference of the symbol at point."
   (interactive)
   (let* ((cur (list buffer-file-name (1- (line-number-at-pos)) (- (point) (line-beginning-position))))
-         (refs (lsp-ui--reference-triples include-declaration))
+         (refs (lsp-ui--reference-triples exclude-declaration))
          (idx -1)
          (res (-last (lambda (ref) (and (lsp-ui--location< ref cur) (cl-incf idx))) refs)))
     (if res


### PR DESCRIPTION
This pull request contains a bugfix and a small improvement.

Last year, `lsp--make-reference-params` had its parameter reversed in emacs-lsp/lsp-mode@2c6a0e92, but no matching change was made here, so the behavior of a few functions became incorrect. The first commit in this pull request fixes those functions.
- For `lsp-ui-peek-find-references`, I left the argument name intact and reversed the value, which restores the previous behavior of not including the declaration by default. This allows `lsp-ui-peek-always-show` to work normally when trying to navigate from a definition to the only usage of the identifier.
- For `lsp-ui-find-{next,prev}-reference`, I changed the name of the argument to `exclude-declaration`, which leaves the previous behavior intact (they include the declaration).

The second commit adds a prefix argument to `lsp-ui-peek-find-references`, allowing a prefix argument to be given to include the declaration in the search, just in case you want to see the definition and references at the same time.