### PR TITLE
Prevent parent window margins from being used in UI doc child frame.

### DIFF
--- a/lsp-ui-doc.el
+++ b/lsp-ui-doc.el
@@ -265,6 +265,8 @@ Because some variables are buffer local.")
          (buffer-list-update-hook nil))
      (with-current-buffer (get-buffer-create (lsp-ui-doc--make-buffer-name))
        (setq lsp-ui-doc--parent-vars parent-vars)
+       (setq left-margin-width 0)
+       (setq right-margin-width 0)
        (prog1 (let ((buffer-read-only nil)
                     (inhibit-modification-hooks t)
                     (inhibit-redisplay t))
@@ -591,6 +593,11 @@ FRAME just below the symbol at point."
        (left-fringe . 0)))
     ;; Insert hr lines after width is computed
     (lsp-ui-doc--fix-hr-props)
+    ;; Force window to use buffer's margin settings instead of the
+    ;; parent window's settings.
+    (let ((window (frame-root-window frame))
+          (buffer (get-buffer (lsp-ui-doc--make-buffer-name))))
+      (set-window-buffer window buffer))
     (unless (frame-visible-p frame)
       (make-frame-visible frame))))
 


### PR DESCRIPTION
When margins are used in the main window (such as Flymake/Flycheck diagnostic indicators in the margin instead of the fringe), causing `left-margin-width` and/or `right-margin-width` in the parent to be non-zero, the child frame was seeing those margins and text was being wrapped incorrectly.

The child frame is sized to handle the amount of text on a line (up to `lsp-ui-doc-max-width`) and then `fill-region` is used to hard-wrap the text.  The computation of the size of the frame assumes there are no fringes or margins which consume part of this frame.  However, when the margin was visible in the child frame, it was causing text to be soft-wrapped prior to the hard-wrap.

This change sets the margin sizes to 0 in the buffer of the child frame and then forces the window of the child frame to utilize these settings, preventing parent margins from being displayed in the child frame.