### PR TITLE
Properly provide and require test-helper

### DIFF
--- a/test/lsp-ui-flycheck-test.el
+++ b/test/lsp-ui-flycheck-test.el
@@ -1,6 +1,7 @@
 ;; -*- lexical-binding: t -*-
 
 (require 'lsp-modeline)
+(require 'test-helper)
 
 (ert-deftest lsp-ui-test-flycheck-list--update ()
   "Test if `lsp-ui-flycheck-list--update' populates buffer *lsp-diagnostics*."

--- a/test/lsp-ui-sideline-test.el
+++ b/test/lsp-ui-sideline-test.el
@@ -1,6 +1,7 @@
 ;; -*- lexical-binding: t -*-
 
 (require 'lsp-modeline)
+(require 'test-helper)
 
 (ert-deftest lsp-ui-test-sideline-overlays ()
   "Basic test if overlays are stored in `lsp-ui-sideline--ovs' and set in buffer after call to

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -34,5 +34,6 @@
       (save-buffer))
     dir))
 
+(provide 'test-helper)
 
 ;;; test-helper.el ends here


### PR DESCRIPTION
* This ensures that tests have access to the helper functions defined in test/test-helper.el.