### PR TITLE
[fix] `lsp-ui` not displaying pop-up on MarkedString[]

### DIFF
--- a/lsp-ui-doc.el
+++ b/lsp-ui-doc.el
@@ -351,7 +351,7 @@ Because some variables are buffer local.")
                             (append list-marked-string nil))))
     (if lsp-ui-doc-include-signature
         list-marked-string
-      (cadr groups))))
+      (cdar groups))))
 
 (defun lsp-ui-doc--extract (contents)
   "Extract the documentation from CONTENTS.


### PR DESCRIPTION
Why?:
- There seems to be a typo in extracting the documentation from an array of MarkedString[]. If `lsp-ui-doc-include-signature` is disabled, we still want to display the documentation in the pop-up which should reside in the rest of the MarkedString[] array excluding the first entry.

This change addresses the need by:
- Turn `cadr` into `cdar` to extract the rest of the first list inside `groups`