### PR TITLE
fix(doc): lsp-ui-sideline-diagnostic-max-lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ When set to 'line' the information will be updated when user
 changes current line otherwise the information will be updated
 when user changes current point
 - `lsp-ui-sideline-delay` seconds to wait before showing sideline
+- `lsp-ui-sideline-diagnostic-max-lines` default to showing only the
+  first line of diagnostic messages, increase for more verbose
+  messages, decrease if flickering occurs
 
 ## lsp-ui-peek:
 


### PR DESCRIPTION
Was experiencing https://github.com/emacs-lsp/lsp-ui/issues/150 and had to look through a number of issues before finding this discussion which explained the user option which can be customized to change the behavior. Document.