### PR TITLE
allow lsp-ui-sideline code action icon to be customizable

### DIFF
--- a/lsp-ui-sideline.el
+++ b/lsp-ui-sideline.el
@@ -512,7 +512,7 @@ Argument HEIGHT is an actual image height in pixel."
                                          (t (error "Function image-size undefined.  Use default icon")))
                                    (lsp-ui-sideline--scale-lightbulb)))))))
 
-(defun lsp-ui-sideline--code-actions-image nil
+(defun lsp-ui-sideline--code-actions-image (action)
   (when lsp-ui-sideline-actions-icon
     (with-demoted-errors "[lsp-ui-sideline]: Error with actions icon: %s"
       (concat
@@ -535,7 +535,7 @@ Argument HEIGHT is an actual image height in pixel."
                           (replace-regexp-in-string " " " ")
                           (concat (unless lsp-ui-sideline-actions-icon
                                     lsp-ui-sideline-code-actions-prefix))))
-              (image (lsp-ui-sideline--code-actions-image))
+              (image (lsp-ui-sideline--code-actions-image action))
               (margin (lsp-ui-sideline--margin-width))
               (keymap (let ((map (make-sparse-keymap)))
                         (define-key map [down-mouse-1] (lambda () (interactive)


### PR DESCRIPTION
Hi,

Currently, the code action icon in lsp-ui-sideline is fixed by `lsp-ui-sideline--code-actions-image`, and it's impossible to advise this function to return different icons for different actions, since there is no parameter provided for that function.

In this PR, I extended the function `lsp-ui-sideline--code-actions-image` with an additional parameter `action` for future usage, so that users can easily advise it to customize the icon.

Please consider merging it.

Thanks!

