### PR TITLE
Fix lsp-ui-doc-mode non-idempotency

### DIFF
--- a/lsp-ui-doc.el
+++ b/lsp-ui-doc.el
@@ -1170,6 +1170,11 @@ If nil, do not prevent mouse on prefix keys.")
 (defun lsp-ui-doc--prevent-focus-doc (e)
   (not (frame-parameter (cadr e) 'lsp-ui-doc--no-focus)))
 
+(defvar lsp-ui-doc-mode--was-already-enabled nil
+  "Whether the minor mode was previously enabled.
+This is used to notice if the mode is enabled again when it was already
+enabled, to avoid re-copying previous state.")
+
 (define-minor-mode lsp-ui-doc-mode
   "Minor mode for showing hover information in child frame."
   :init-value nil
@@ -1189,7 +1194,10 @@ If nil, do not prevent mouse on prefix keys.")
         (push '(lsp-ui-doc-frame . :never) frameset-filter-alist)))
     (when (boundp 'window-state-change-functions)
       (add-hook 'window-state-change-functions 'lsp-ui-doc--on-state-changed))
-    (lsp-ui-doc--setup-mouse)
+    (unless lsp-ui-doc-mode--was-already-enabled
+      ;; This function is not idempotent, avoid running twice in a
+      ;; row.
+      (lsp-ui-doc--setup-mouse))
     (advice-add 'handle-switch-frame :before-while 'lsp-ui-doc--prevent-focus-doc)
     (add-hook 'post-command-hook 'lsp-ui-doc--make-request nil t)
     (add-hook 'window-scroll-functions 'lsp-ui-doc--handle-scroll nil t)
@@ -1200,7 +1208,8 @@ If nil, do not prevent mouse on prefix keys.")
       (remove-hook 'window-state-change-functions 'lsp-ui-doc--on-state-changed))
     (remove-hook 'window-scroll-functions 'lsp-ui-doc--handle-scroll t)
     (remove-hook 'post-command-hook 'lsp-ui-doc--make-request t)
-    (remove-hook 'delete-frame-functions 'lsp-ui-doc--on-delete t))))
+    (remove-hook 'delete-frame-functions 'lsp-ui-doc--on-delete t)))
+  (setq lsp-ui-doc-mode--was-already-enabled lsp-ui-doc-mode))
 
 (defun lsp-ui-doc-enable (enable)
   "Enable/disable ‘lsp-ui-doc-mode’.

--- a/lsp-ui-doc.el
+++ b/lsp-ui-doc.el
@@ -1170,7 +1170,7 @@ If nil, do not prevent mouse on prefix keys.")
 (defun lsp-ui-doc--prevent-focus-doc (e)
   (not (frame-parameter (cadr e) 'lsp-ui-doc--no-focus)))
 
-(defvar lsp-ui-doc-mode--was-already-enabled nil
+(defvar-local lsp-ui-doc-mode--was-already-enabled nil
   "Whether the minor mode was previously enabled.
 This is used to notice if the mode is enabled again when it was already
 enabled, to avoid re-copying previous state.")


### PR DESCRIPTION
Per https://www.gnu.org/software/emacs/manual/html_node/elisp/Minor-Mode-Conventions.html:

> Enabling or disabling a minor mode twice in direct succession should not fail and should do the same thing as enabling or disabling it only once. In other words, the minor mode command should be idempotent. 

The existing implementation of `lsp-ui-doc-mode` was not idempotent. The first time it was enabled, it ran `lsp-ui-doc--setup-mouse`, which invoked:

```elisp
(setq lsp-ui-doc--mouse-tracked-by-us (not track-mouse))
(setq-local track-mouse t)
```

The second time it was enabled, it did the same thing, but now `track-mouse` was already non-nil, making `lsp-ui-doc--mouse-tracked-by-us` nil, even though `lsp-ui-doc` was in fact tracking the mouse. As a consequence, `lsp-ui-doc--disable-mouse-on-prefix` stopped functioning, causing a bug similar to https://github.com/emacs-lsp/lsp-ui/issues/795, where if you typed a prefix key such as `C-x` and then moved the mouse (in a buffer where lsp-ui-doc-mode was enabled) it would abort the key sequence.

You might not expect this sequence of events to come up commonly, but the default configuration of lsp-mode (or at least the one running in my config) apparently invokes `(lsp-ui-doc-mode 1)` three separate times when setting up a new buffer. I don't know why. But this caused the prefix bug to trigger universally for me.

I resolved the issue by adding a second mode variable for tracking whether or not `lsp-ui-doc--setup-mouse` needs to be run again. There may be additional idempotency issues, but this resolves one of them, at least.