### PR TITLE
fix: use flycheck-error-level-error-list-face for sideline diagnostic face resolution

### DIFF
--- a/lsp-ui-sideline.el
+++ b/lsp-ui-sideline.el
@@ -470,7 +470,7 @@ Push sideline overlays on `lsp-ui-sideline--ovs'."
                  (msg (replace-regexp-in-string " " " " msg))
                  (len (length msg))
                  (level (flycheck-error-level e))
-                 (face (if (eq level 'info) 'success level))
+		 (face (or (flycheck-error-level-error-list-face level) level))
                  (margin (lsp-ui-sideline--margin-width))
                  (msg (progn (add-face-text-property 0 len 'lsp-ui-sideline-global nil msg)
                              (add-face-text-property 0 len face nil msg)


### PR DESCRIPTION
**Fix `Invalid face reference` for custom flycheck error levels in sideline diagnostics**

The face for sideline diagnostics was resolved by using the level symbol directly as a face name:

```elisp
(face (if (eq level 'info) 'success level))
```

This accidentally worked for built-in levels because Emacs has faces named `error` and `warning`, but breaks for custom levels created by `lsp-mode` like `lsp-flycheck-info-unnecessary` since no face with that exact name exists, producing `Invalid face reference: lsp-flycheck-info-unnecessary`.

Fix uses flycheck's API to look up the face registered for the level:

```elisp
(face (or (flycheck-error-level-error-list-face level) level))
```

Before - invalid face reference error in *Messages* and wrong faces for sideline diagnostics:

<img width="3050" height="340" alt="image" src="https://github.com/user-attachments/assets/1e44acb3-2dc1-415f-92c7-4873c1b3a662" />

<img width="1534" height="148" alt="image" src="https://github.com/user-attachments/assets/31e3f704-ca84-49dd-979c-ee26e915d8cd" />

After - error gone, sideline diagnostics displaying correctly:

<img width="3050" height="330" alt="image" src="https://github.com/user-attachments/assets/e2fc59b4-0f2e-43c6-a4e8-33226bc2f63a" />

